### PR TITLE
React Spectrum: Compat with React 19 types

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
-    "@types/react": "^18.2.28",
+    "@types/react": "npm:types-react@19.0.0-alpha.2",
     "@types/storybook__react": "^5.2.1",
     "@typescript-eslint/eslint-plugin": "^6.7.5",
     "@typescript-eslint/parser": "^6.7.5",
@@ -181,7 +181,8 @@
   },
   "resolutions": {
     "@babel/core": "7.12.10",
-    "@types/react": "18.2.28",
+    "@types/react": "npm:types-react@19.0.0-alpha.2",
+    "@types/react-dom": "npm:types-react-dom@19.0.0-alpha.2",
     "postcss": "8.4.24",
     "postcss-custom-properties": "13.2.0",
     "postcss-import": "15.1.0",

--- a/packages/@react-aria/accordion/src/useAccordion.ts
+++ b/packages/@react-aria/accordion/src/useAccordion.ts
@@ -34,7 +34,7 @@ export interface AccordionItemAria {
   regionProps: DOMAttributes
 }
 
-export function useAccordionItem<T>(props: AccordionItemAriaProps<T>, state: TreeState<T>, ref: RefObject<HTMLButtonElement>): AccordionItemAria {
+export function useAccordionItem<T>(props: AccordionItemAriaProps<T>, state: TreeState<T>, ref: RefObject<HTMLButtonElement | null>): AccordionItemAria {
   let {item} = props;
   let buttonId = useId();
   let regionId = useId();
@@ -65,7 +65,7 @@ export function useAccordionItem<T>(props: AccordionItemAriaProps<T>, state: Tre
   };
 }
 
-export function useAccordion<T>(props: AriaAccordionProps<T>, state: TreeState<T>, ref: RefObject<HTMLDivElement>): AccordionAria {
+export function useAccordion<T>(props: AriaAccordionProps<T>, state: TreeState<T>, ref: RefObject<HTMLDivElement | null>): AccordionAria {
   let {listProps} = useSelectableList({
     ...props,
     ...state,

--- a/packages/@react-aria/actiongroup/src/useActionGroup.ts
+++ b/packages/@react-aria/actiongroup/src/useActionGroup.ts
@@ -28,7 +28,7 @@ export interface ActionGroupAria {
   actionGroupProps: DOMAttributes
 }
 
-export function useActionGroup<T>(props: AriaActionGroupProps<T>, state: ListState<T>, ref: RefObject<FocusableElement>): ActionGroupAria {
+export function useActionGroup<T>(props: AriaActionGroupProps<T>, state: ListState<T>, ref: RefObject<FocusableElement | null>): ActionGroupAria {
   let {
     isDisabled,
     orientation = 'horizontal' as Orientation

--- a/packages/@react-aria/actiongroup/src/useActionGroupItem.ts
+++ b/packages/@react-aria/actiongroup/src/useActionGroupItem.ts
@@ -31,7 +31,7 @@ const BUTTON_ROLES = {
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function useActionGroupItem<T>(props: AriaActionGroupItemProps, state: ListState<T>, ref?: RefObject<FocusableElement>): ActionGroupItemAria {
+export function useActionGroupItem<T>(props: AriaActionGroupItemProps, state: ListState<T>, ref?: RefObject<FocusableElement | null>): ActionGroupItemAria {
   let selectionMode = state.selectionManager.selectionMode;
   let buttonProps = {
     role: BUTTON_ROLES[selectionMode]

--- a/packages/@react-aria/autocomplete/src/useSearchAutocomplete.ts
+++ b/packages/@react-aria/autocomplete/src/useSearchAutocomplete.ts
@@ -37,11 +37,11 @@ export interface SearchAutocompleteAria<T> extends ValidationResult {
 
 export interface AriaSearchAutocompleteOptions<T> extends AriaSearchAutocompleteProps<T> {
   /** The ref for the input element. */
-  inputRef: RefObject<HTMLInputElement>,
+  inputRef: RefObject<HTMLInputElement | null>,
   /** The ref for the list box popover. */
-  popoverRef: RefObject<HTMLDivElement>,
+  popoverRef: RefObject<HTMLDivElement | null>,
   /** The ref for the list box. */
-  listBoxRef: RefObject<HTMLElement>,
+  listBoxRef: RefObject<HTMLElement | null>,
   /** An optional keyboard delegate implementation, to override the default. */
   keyboardDelegate?: KeyboardDelegate
 }

--- a/packages/@react-aria/breadcrumbs/src/useBreadcrumbItem.ts
+++ b/packages/@react-aria/breadcrumbs/src/useBreadcrumbItem.ts
@@ -24,7 +24,7 @@ export interface BreadcrumbItemAria {
  * Provides the behavior and accessibility implementation for an in a breadcrumbs component.
  * See `useBreadcrumbs` for details about breadcrumbs.
  */
-export function useBreadcrumbItem(props: AriaBreadcrumbItemProps, ref: RefObject<FocusableElement>): BreadcrumbItemAria {
+export function useBreadcrumbItem(props: AriaBreadcrumbItemProps, ref: RefObject<FocusableElement | null>): BreadcrumbItemAria {
   let {
     isCurrent,
     isDisabled,

--- a/packages/@react-aria/button/src/useButton.ts
+++ b/packages/@react-aria/button/src/useButton.ts
@@ -34,12 +34,12 @@ export interface ButtonAria<T> {
 }
 
 // Order with overrides is important: 'button' should be default
-export function useButton(props: AriaButtonOptions<'button'>, ref: RefObject<HTMLButtonElement>): ButtonAria<ButtonHTMLAttributes<HTMLButtonElement>>;
-export function useButton(props: AriaButtonOptions<'a'>, ref: RefObject<HTMLAnchorElement>): ButtonAria<AnchorHTMLAttributes<HTMLAnchorElement>>;
-export function useButton(props: AriaButtonOptions<'div'>, ref: RefObject<HTMLDivElement>): ButtonAria<HTMLAttributes<HTMLDivElement>>;
-export function useButton(props: AriaButtonOptions<'input'>, ref: RefObject<HTMLInputElement>): ButtonAria<InputHTMLAttributes<HTMLInputElement>>;
-export function useButton(props: AriaButtonOptions<'span'>, ref: RefObject<HTMLSpanElement>): ButtonAria<HTMLAttributes<HTMLSpanElement>>;
-export function useButton(props: AriaButtonOptions<ElementType>, ref: RefObject<Element>): ButtonAria<DOMAttributes>;
+export function useButton(props: AriaButtonOptions<'button'>, ref: RefObject<HTMLButtonElement | null>): ButtonAria<ButtonHTMLAttributes<HTMLButtonElement>>;
+export function useButton(props: AriaButtonOptions<'a'>, ref: RefObject<HTMLAnchorElement | null>): ButtonAria<AnchorHTMLAttributes<HTMLAnchorElement>>;
+export function useButton(props: AriaButtonOptions<'div'>, ref: RefObject<HTMLDivElement | null>): ButtonAria<HTMLAttributes<HTMLDivElement>>;
+export function useButton(props: AriaButtonOptions<'input'>, ref: RefObject<HTMLInputElement | null>): ButtonAria<InputHTMLAttributes<HTMLInputElement>>;
+export function useButton(props: AriaButtonOptions<'span'>, ref: RefObject<HTMLSpanElement | null>): ButtonAria<HTMLAttributes<HTMLSpanElement>>;
+export function useButton(props: AriaButtonOptions<ElementType>, ref: RefObject<Element | null>): ButtonAria<DOMAttributes>;
 /**
  * Provides the behavior and accessibility implementation for a button component. Handles mouse, keyboard, and touch interactions,
  * focus behavior, and ARIA props for both native button elements and custom element types.

--- a/packages/@react-aria/button/src/useToggleButton.ts
+++ b/packages/@react-aria/button/src/useToggleButton.ts
@@ -27,12 +27,12 @@ import {ToggleState} from '@react-stately/toggle';
 export interface AriaToggleButtonOptions<E extends ElementType> extends Omit<AriaToggleButtonProps<E>, 'children'> {}
 
 // Order with overrides is important: 'button' should be default
-export function useToggleButton(props: AriaToggleButtonOptions<'button'>, state: ToggleState, ref: RefObject<HTMLButtonElement>): ButtonAria<ButtonHTMLAttributes<HTMLButtonElement>>;
-export function useToggleButton(props: AriaToggleButtonOptions<'a'>, state: ToggleState, ref: RefObject<HTMLAnchorElement>): ButtonAria<AnchorHTMLAttributes<HTMLAnchorElement>>;
-export function useToggleButton(props: AriaToggleButtonOptions<'div'>, state: ToggleState, ref: RefObject<HTMLDivElement>): ButtonAria<HTMLAttributes<HTMLDivElement>>;
-export function useToggleButton(props: AriaToggleButtonOptions<'input'>, state: ToggleState, ref: RefObject<HTMLInputElement>): ButtonAria<InputHTMLAttributes<HTMLInputElement>>;
-export function useToggleButton(props: AriaToggleButtonOptions<'span'>, state: ToggleState, ref: RefObject<HTMLSpanElement>): ButtonAria<HTMLAttributes<HTMLSpanElement>>;
-export function useToggleButton(props: AriaToggleButtonOptions<ElementType>, state: ToggleState, ref: RefObject<Element>): ButtonAria<DOMAttributes>;
+export function useToggleButton(props: AriaToggleButtonOptions<'button'>, state: ToggleState, ref: RefObject<HTMLButtonElement | null>): ButtonAria<ButtonHTMLAttributes<HTMLButtonElement>>;
+export function useToggleButton(props: AriaToggleButtonOptions<'a'>, state: ToggleState, ref: RefObject<HTMLAnchorElement | null>): ButtonAria<AnchorHTMLAttributes<HTMLAnchorElement>>;
+export function useToggleButton(props: AriaToggleButtonOptions<'div'>, state: ToggleState, ref: RefObject<HTMLDivElement | null>): ButtonAria<HTMLAttributes<HTMLDivElement>>;
+export function useToggleButton(props: AriaToggleButtonOptions<'input'>, state: ToggleState, ref: RefObject<HTMLInputElement | null>): ButtonAria<InputHTMLAttributes<HTMLInputElement>>;
+export function useToggleButton(props: AriaToggleButtonOptions<'span'>, state: ToggleState, ref: RefObject<HTMLSpanElement | null>): ButtonAria<HTMLAttributes<HTMLSpanElement>>;
+export function useToggleButton(props: AriaToggleButtonOptions<ElementType>, state: ToggleState, ref: RefObject<Element | null>): ButtonAria<DOMAttributes>;
 /**
  * Provides the behavior and accessibility implementation for a toggle button component.
  * ToggleButtons allow users to toggle a selection on or off, for example switching between two states or modes.

--- a/packages/@react-aria/calendar/src/useCalendarCell.ts
+++ b/packages/@react-aria/calendar/src/useCalendarCell.ts
@@ -72,7 +72,7 @@ export interface CalendarCellAria {
  * Provides the behavior and accessibility implementation for a calendar cell component.
  * A calendar cell displays a date cell within a calendar grid which can be selected by the user.
  */
-export function useCalendarCell(props: AriaCalendarCellProps, state: CalendarState | RangeCalendarState, ref: RefObject<HTMLElement>): CalendarCellAria {
+export function useCalendarCell(props: AriaCalendarCellProps, state: CalendarState | RangeCalendarState, ref: RefObject<HTMLElement | null>): CalendarCellAria {
   let {date, isDisabled} = props;
   let {errorMessageId, selectedDateDescription} = hookData.get(state);
   let stringFormatter = useLocalizedStringFormatter(intlMessages, '@react-aria/calendar');

--- a/packages/@react-aria/calendar/src/useRangeCalendar.ts
+++ b/packages/@react-aria/calendar/src/useRangeCalendar.ts
@@ -21,7 +21,7 @@ import {useEvent} from '@react-aria/utils';
  * Provides the behavior and accessibility implementation for a range calendar component.
  * A range calendar displays one or more date grids and allows users to select a contiguous range of dates.
  */
-export function useRangeCalendar<T extends DateValue>(props: AriaRangeCalendarProps<T>, state: RangeCalendarState, ref: RefObject<FocusableElement>): CalendarAria {
+export function useRangeCalendar<T extends DateValue>(props: AriaRangeCalendarProps<T>, state: RangeCalendarState, ref: RefObject<FocusableElement | null>): CalendarAria {
   let res = useCalendarBase(props, state);
 
   // We need to ignore virtual pointer events from VoiceOver due to these bugs.

--- a/packages/@react-aria/calendar/stories/Example.tsx
+++ b/packages/@react-aria/calendar/stories/Example.tsx
@@ -82,7 +82,7 @@ function CalendarGrid({state, visibleDuration, offset = {}}: {state: CalendarSta
 }
 
 function Cell(props) {
-  let ref = useRef();
+  let ref = useRef(undefined);
   let {cellProps, buttonProps} = useCalendarCell(props, props.state, ref);
 
   let dateFormatter = useDateFormatter({

--- a/packages/@react-aria/checkbox/src/useCheckbox.ts
+++ b/packages/@react-aria/checkbox/src/useCheckbox.ts
@@ -41,7 +41,7 @@ export interface CheckboxAria extends ValidationResult {
  * @param state - State for the checkbox, as returned by `useToggleState`.
  * @param inputRef - A ref for the HTML input element.
  */
-export function useCheckbox(props: AriaCheckboxProps, state: ToggleState, inputRef: RefObject<HTMLInputElement>): CheckboxAria {
+export function useCheckbox(props: AriaCheckboxProps, state: ToggleState, inputRef: RefObject<HTMLInputElement | null>): CheckboxAria {
   // Create validation state here because it doesn't make sense to add to general useToggleState.
   let validationState = useFormValidationState({...props, value: state.isSelected});
   let {isInvalid, validationErrors, validationDetails} = validationState.displayValidation;

--- a/packages/@react-aria/checkbox/src/useCheckboxGroupItem.ts
+++ b/packages/@react-aria/checkbox/src/useCheckboxGroupItem.ts
@@ -26,7 +26,7 @@ import {ValidationResult} from '@react-types/shared';
  * @param state - State for the checkbox, as returned by `useCheckboxGroupState`.
  * @param inputRef - A ref for the HTML input element.
  */
-export function useCheckboxGroupItem(props: AriaCheckboxGroupItemProps, state: CheckboxGroupState, inputRef: RefObject<HTMLInputElement>): CheckboxAria {
+export function useCheckboxGroupItem(props: AriaCheckboxGroupItemProps, state: CheckboxGroupState, inputRef: RefObject<HTMLInputElement | null>): CheckboxAria {
   const toggleState = useToggleState({
     isReadOnly: props.isReadOnly || state.isReadOnly,
     isSelected: state.isSelected(props.value),

--- a/packages/@react-aria/color/src/useColorArea.ts
+++ b/packages/@react-aria/color/src/useColorArea.ts
@@ -37,11 +37,11 @@ export interface ColorAreaAria {
 
 export interface AriaColorAreaOptions extends AriaColorAreaProps {
   /** A ref to the input that represents the x axis of the color area. */
-  inputXRef: RefObject<HTMLInputElement>,
+  inputXRef: RefObject<HTMLInputElement | null>,
   /** A ref to the input that represents the y axis of the color area. */
-  inputYRef: RefObject<HTMLInputElement>,
+  inputYRef: RefObject<HTMLInputElement | null>,
   /** A ref to the color area containing element. */
-  containerRef: RefObject<Element>
+  containerRef: RefObject<Element | null>
 }
 
 /**
@@ -65,7 +65,7 @@ export function useColorArea(props: AriaColorAreaOptions, state: ColorAreaState)
   let {direction, locale} = useLocale();
 
   let [focusedInput, setFocusedInput] = useState<'x' | 'y' | null>(null);
-  let focusInput = useCallback((inputRef:RefObject<HTMLInputElement> = inputXRef) => {
+  let focusInput = useCallback((inputRef:RefObject<HTMLInputElement | null> = inputXRef) => {
     if (inputRef.current) {
       focusWithoutScrolling(inputRef.current);
     }

--- a/packages/@react-aria/color/src/useColorField.ts
+++ b/packages/@react-aria/color/src/useColorField.ts
@@ -40,7 +40,7 @@ export interface ColorFieldAria extends ValidationResult {
 export function useColorField(
   props: AriaColorFieldProps,
   state: ColorFieldState,
-  ref: RefObject<HTMLInputElement>
+  ref: RefObject<HTMLInputElement | null>
 ): ColorFieldAria {
   let {
     isDisabled,

--- a/packages/@react-aria/color/src/useColorSlider.ts
+++ b/packages/@react-aria/color/src/useColorSlider.ts
@@ -20,9 +20,9 @@ import {useSlider, useSliderThumb} from '@react-aria/slider';
 
 export interface AriaColorSliderOptions extends AriaColorSliderProps {
   /** A ref for the track element. */
-  trackRef: RefObject<Element>,
+  trackRef: RefObject<Element | null>,
   /** A ref for the input element. */
-  inputRef: RefObject<HTMLInputElement>
+  inputRef: RefObject<HTMLInputElement | null>
 }
 
 export interface ColorSliderAria {

--- a/packages/@react-aria/color/src/useColorWheel.ts
+++ b/packages/@react-aria/color/src/useColorWheel.ts
@@ -38,7 +38,7 @@ export interface ColorWheelAria {
  * Provides the behavior and accessibility implementation for a color wheel component.
  * Color wheels allow users to adjust the hue of an HSL or HSB color value on a circular track.
  */
-export function useColorWheel(props: AriaColorWheelOptions, state: ColorWheelState, inputRef: RefObject<HTMLInputElement>): ColorWheelAria {
+export function useColorWheel(props: AriaColorWheelOptions, state: ColorWheelState, inputRef: RefObject<HTMLInputElement | null>): ColorWheelAria {
   let {
     isDisabled,
     innerRadius,

--- a/packages/@react-aria/combobox/src/useComboBox.ts
+++ b/packages/@react-aria/combobox/src/useComboBox.ts
@@ -30,13 +30,13 @@ import {useTextField} from '@react-aria/textfield';
 
 export interface AriaComboBoxOptions<T> extends Omit<AriaComboBoxProps<T>, 'children'> {
   /** The ref for the input element. */
-  inputRef: RefObject<HTMLInputElement>,
+  inputRef: RefObject<HTMLInputElement | null>,
   /** The ref for the list box popover. */
-  popoverRef: RefObject<Element>,
+  popoverRef: RefObject<Element | null>,
   /** The ref for the list box. */
-  listBoxRef: RefObject<HTMLElement>,
+  listBoxRef: RefObject<HTMLElement | null>,
   /** The ref for the optional list box popup trigger button.  */
-  buttonRef?: RefObject<Element>,
+  buttonRef?: RefObject<Element | null>,
   /** An optional keyboard delegate implementation, to override the default. */
   keyboardDelegate?: KeyboardDelegate
 }

--- a/packages/@react-aria/combobox/stories/example.tsx
+++ b/packages/@react-aria/combobox/stories/example.tsx
@@ -86,7 +86,7 @@ export function ComboBox(props) {
 }
 
 function Popover(props) {
-  let ref = React.useRef();
+  let ref = React.useRef(undefined);
   let {
     popoverRef = ref,
     isOpen,
@@ -126,7 +126,7 @@ function Popover(props) {
 
 
 function ListBox(props) {
-  let ref = React.useRef();
+  let ref = React.useRef(undefined);
   let {listBoxRef = ref, state} = props;
   let {listBoxProps} = useListBox(props, state, listBoxRef);
 
@@ -152,7 +152,7 @@ function ListBox(props) {
 }
 
 function Option({item, state}) {
-  let ref = React.useRef();
+  let ref = React.useRef(undefined);
   let {optionProps, isSelected, isFocused, isDisabled} = useOption({key: item.key}, state, ref);
 
   let backgroundColor;

--- a/packages/@react-aria/datepicker/src/useDateField.ts
+++ b/packages/@react-aria/datepicker/src/useDateField.ts
@@ -27,7 +27,7 @@ import {useLocalizedStringFormatter} from '@react-aria/i18n';
 // Allows this hook to also be used with TimeField
 export interface AriaDateFieldOptions<T extends DateValue> extends Omit<AriaDateFieldPropsBase<T>, 'value' | 'defaultValue' | 'onChange' | 'minValue' | 'maxValue' | 'placeholderValue' | 'validate'> {
   /** A ref for the hidden input element for HTML form submission. */
-  inputRef?: RefObject<HTMLInputElement>
+  inputRef?: RefObject<HTMLInputElement | null>
 }
 
 export interface DateFieldAria extends ValidationResult {
@@ -63,7 +63,7 @@ export const focusManagerSymbol = '__focusManager_' + Date.now();
  * A date field allows users to enter and edit date and time values using a keyboard.
  * Each part of a date value is displayed in an individually editable segment.
  */
-export function useDateField<T extends DateValue>(props: AriaDateFieldOptions<T>, state: DateFieldState, ref: RefObject<Element>): DateFieldAria {
+export function useDateField<T extends DateValue>(props: AriaDateFieldOptions<T>, state: DateFieldState, ref: RefObject<Element | null>): DateFieldAria {
   let {isInvalid, validationErrors, validationDetails} = state.displayValidation;
   let {labelProps, fieldProps, descriptionProps, errorMessageProps} = useField({
     ...props,
@@ -193,7 +193,7 @@ export function useDateField<T extends DateValue>(props: AriaDateFieldOptions<T>
 
 export interface AriaTimeFieldOptions<T extends TimeValue> extends AriaTimeFieldProps<T> {
   /** A ref for the hidden input element for HTML form submission. */
-  inputRef?: RefObject<HTMLInputElement>
+  inputRef?: RefObject<HTMLInputElement | null>
 }
 
 /**
@@ -201,7 +201,7 @@ export interface AriaTimeFieldOptions<T extends TimeValue> extends AriaTimeField
  * A time field allows users to enter and edit time values using a keyboard.
  * Each part of a time value is displayed in an individually editable segment.
  */
-export function useTimeField<T extends TimeValue>(props: AriaTimeFieldOptions<T>, state: TimeFieldState, ref: RefObject<Element>): DateFieldAria {
+export function useTimeField<T extends TimeValue>(props: AriaTimeFieldOptions<T>, state: TimeFieldState, ref: RefObject<Element | null>): DateFieldAria {
   let res = useDateField(props, state, ref);
   res.inputProps.value = state.timeValue?.toString() || '';
   return res;

--- a/packages/@react-aria/datepicker/src/useDatePicker.ts
+++ b/packages/@react-aria/datepicker/src/useDatePicker.ts
@@ -51,7 +51,7 @@ export interface DatePickerAria extends ValidationResult {
  * Provides the behavior and accessibility implementation for a date picker component.
  * A date picker combines a DateField and a Calendar popover to allow users to enter or select a date and time value.
  */
-export function useDatePicker<T extends DateValue>(props: AriaDatePickerProps<T>, state: DatePickerState, ref: RefObject<Element>): DatePickerAria {
+export function useDatePicker<T extends DateValue>(props: AriaDatePickerProps<T>, state: DatePickerState, ref: RefObject<Element | null>): DatePickerAria {
   let buttonId = useId();
   let dialogId = useId();
   let fieldId = useId();

--- a/packages/@react-aria/datepicker/src/useDatePickerGroup.ts
+++ b/packages/@react-aria/datepicker/src/useDatePickerGroup.ts
@@ -6,7 +6,7 @@ import {RefObject, useMemo} from 'react';
 import {useLocale} from '@react-aria/i18n';
 import {usePress} from '@react-aria/interactions';
 
-export function useDatePickerGroup(state: DatePickerState | DateRangePickerState | DateFieldState, ref: RefObject<Element>, disableArrowNavigation?: boolean) {
+export function useDatePickerGroup(state: DatePickerState | DateRangePickerState | DateFieldState, ref: RefObject<Element | null>, disableArrowNavigation?: boolean) {
   let {direction} = useLocale();
   let focusManager = useMemo(() => createFocusManager(ref), [ref]);
 

--- a/packages/@react-aria/datepicker/src/useDateRangePicker.ts
+++ b/packages/@react-aria/datepicker/src/useDateRangePicker.ts
@@ -54,7 +54,7 @@ export interface DateRangePickerAria extends ValidationResult {
  * A date range picker combines two DateFields and a RangeCalendar popover to allow
  * users to enter or select a date and time range.
  */
-export function useDateRangePicker<T extends DateValue>(props: AriaDateRangePickerProps<T>, state: DateRangePickerState, ref: RefObject<Element>): DateRangePickerAria {
+export function useDateRangePicker<T extends DateValue>(props: AriaDateRangePickerProps<T>, state: DateRangePickerState, ref: RefObject<Element | null>): DateRangePickerAria {
   let stringFormatter = useLocalizedStringFormatter(intlMessages, '@react-aria/datepicker');
   let {isInvalid, validationErrors, validationDetails} = state.displayValidation;
   let {labelProps, fieldProps, descriptionProps, errorMessageProps} = useField({

--- a/packages/@react-aria/datepicker/src/useDateSegment.ts
+++ b/packages/@react-aria/datepicker/src/useDateSegment.ts
@@ -31,7 +31,7 @@ export interface DateSegmentAria {
  * A date segment displays an individual unit of a date and time, and allows users to edit
  * the value by typing or using the arrow keys to increment and decrement.
  */
-export function useDateSegment(segment: DateSegment, state: DateFieldState, ref: RefObject<HTMLElement>): DateSegmentAria {
+export function useDateSegment(segment: DateSegment, state: DateFieldState, ref: RefObject<HTMLElement | null>): DateSegmentAria {
   let enteredKeys = useRef('');
   let {locale} = useLocale();
   let displayNames = useDisplayNames();

--- a/packages/@react-aria/dialog/src/useDialog.ts
+++ b/packages/@react-aria/dialog/src/useDialog.ts
@@ -29,7 +29,7 @@ export interface DialogAria {
  * Provides the behavior and accessibility implementation for a dialog component.
  * A dialog is an overlay shown above other content in an application.
  */
-export function useDialog(props: AriaDialogProps, ref: RefObject<FocusableElement>): DialogAria {
+export function useDialog(props: AriaDialogProps, ref: RefObject<FocusableElement | null>): DialogAria {
   let {role = 'dialog'} = props;
   let titleId: string | undefined = useSlotId();
   titleId = props['aria-label'] ? undefined : titleId;

--- a/packages/@react-aria/dnd/src/DragPreview.tsx
+++ b/packages/@react-aria/dnd/src/DragPreview.tsx
@@ -18,7 +18,7 @@ export interface DragPreviewProps {
   children: (items: DragItem[]) => JSX.Element
 }
 
-function DragPreview(props: DragPreviewProps, ref: RefObject<DragPreviewRenderer>) {
+function DragPreview(props: DragPreviewProps, ref: RefObject<DragPreviewRenderer | null>) {
   let render = props.children;
   let [children, setChildren] = useState<JSX.Element>(null);
   let domRef = useRef(null);

--- a/packages/@react-aria/dnd/src/ListDropTargetDelegate.ts
+++ b/packages/@react-aria/dnd/src/ListDropTargetDelegate.ts
@@ -31,12 +31,12 @@ interface ListDropTargetDelegateOptions {
 
 export class ListDropTargetDelegate implements DropTargetDelegate {
   private collection: Collection<Node<unknown>>;
-  private ref: RefObject<HTMLElement>;
+  private ref: RefObject<HTMLElement | null>;
   private layout: 'stack' | 'grid';
   private orientation: Orientation;
   private direction: Direction;
 
-  constructor(collection: Collection<Node<unknown>>, ref: RefObject<HTMLElement>, options?: ListDropTargetDelegateOptions) {
+  constructor(collection: Collection<Node<unknown>>, ref: RefObject<HTMLElement | null>, options?: ListDropTargetDelegateOptions) {
     this.collection = collection;
     this.ref = ref;
     this.layout = options?.layout || 'stack';

--- a/packages/@react-aria/dnd/src/useAutoScroll.ts
+++ b/packages/@react-aria/dnd/src/useAutoScroll.ts
@@ -15,7 +15,7 @@ import {RefObject, useCallback, useEffect, useRef} from 'react';
 
 const AUTOSCROLL_AREA_SIZE = 20;
 
-export function useAutoScroll(ref: RefObject<Element>) {
+export function useAutoScroll(ref: RefObject<Element | null>) {
   let scrollableRef = useRef<Element>(null);
   let scrollableX = useRef(true);
   let scrollableY = useRef(true);

--- a/packages/@react-aria/dnd/src/useDrag.ts
+++ b/packages/@react-aria/dnd/src/useDrag.ts
@@ -31,7 +31,7 @@ export interface DragOptions {
   /** A function that returns the items being dragged. */
   getItems: () => DragItem[],
   /** The ref of the element that will be rendered as the drag preview while dragging. */
-  preview?: RefObject<DragPreviewRenderer>,
+  preview?: RefObject<DragPreviewRenderer | null>,
   /** Function that returns the drop operations that are allowed for the dragged items. If not provided, all drop operations are allowed. */
   getAllowedDropOperations?: () => DropOperation[],
   /**

--- a/packages/@react-aria/dnd/src/useDraggableCollection.ts
+++ b/packages/@react-aria/dnd/src/useDraggableCollection.ts
@@ -20,7 +20,7 @@ export interface DraggableCollectionOptions {}
  * Handles drag interactions for a collection component, with support for traditional mouse and touch
  * based drag and drop, in addition to full parity for keyboard and screen reader users.
  */
-export function useDraggableCollection(props: DraggableCollectionOptions, state: DraggableCollectionState, ref: RefObject<HTMLElement>): void {
+export function useDraggableCollection(props: DraggableCollectionOptions, state: DraggableCollectionState, ref: RefObject<HTMLElement | null>): void {
   // Update global DnD state if this keys within this collection are dragged
   let {draggingCollectionRef} = globalDndState;
   if  (state.draggingKeys.size > 0 && draggingCollectionRef?.current !== ref.current) {

--- a/packages/@react-aria/dnd/src/useDrop.ts
+++ b/packages/@react-aria/dnd/src/useDrop.ts
@@ -21,7 +21,7 @@ import {useVirtualDrop} from './useVirtualDrop';
 
 export interface DropOptions {
   /** A ref for the droppable element. */
-  ref: RefObject<HTMLElement>,
+  ref: RefObject<HTMLElement | null>,
   /**
    * A function returning the drop operation to be performed when items matching the given types are dropped
    * on the drop target.

--- a/packages/@react-aria/dnd/src/useDropIndicator.ts
+++ b/packages/@react-aria/dnd/src/useDropIndicator.ts
@@ -41,7 +41,7 @@ export interface DropIndicatorAria {
 /**
  * Handles drop interactions for a target within a droppable collection.
  */
-export function useDropIndicator(props: DropIndicatorProps, state: DroppableCollectionState, ref: RefObject<HTMLElement>): DropIndicatorAria {
+export function useDropIndicator(props: DropIndicatorProps, state: DroppableCollectionState, ref: RefObject<HTMLElement | null>): DropIndicatorAria {
   let {target} = props;
   let {collection} = state;
 

--- a/packages/@react-aria/dnd/src/useDroppableCollection.ts
+++ b/packages/@react-aria/dnd/src/useDroppableCollection.ts
@@ -67,7 +67,7 @@ const DROP_POSITIONS_RTL: DropPosition[] = ['after', 'on', 'before'];
  * Handles drop interactions for a collection component, with support for traditional mouse and touch
  * based drag and drop, in addition to full parity for keyboard and screen reader users.
  */
-export function useDroppableCollection(props: DroppableCollectionOptions, state: DroppableCollectionState, ref: RefObject<HTMLElement>): DroppableCollectionResult {
+export function useDroppableCollection(props: DroppableCollectionOptions, state: DroppableCollectionState, ref: RefObject<HTMLElement | null>): DroppableCollectionResult {
   let localState = useRef({
     props,
     state,

--- a/packages/@react-aria/dnd/src/useDroppableItem.ts
+++ b/packages/@react-aria/dnd/src/useDroppableItem.ts
@@ -32,7 +32,7 @@ export interface DroppableItemResult {
 /**
  * Handles drop interactions for an item within a collection component.
  */
-export function useDroppableItem(options: DroppableItemOptions, state: DroppableCollectionState, ref: RefObject<HTMLElement>): DroppableItemResult {
+export function useDroppableItem(options: DroppableItemOptions, state: DroppableCollectionState, ref: RefObject<HTMLElement | null>): DroppableItemResult {
   let {dropProps} = useVirtualDrop();
   let droppableCollectionRef = getDroppableCollectionRef(state);
   useEffect(() => {

--- a/packages/@react-aria/dnd/src/utils.ts
+++ b/packages/@react-aria/dnd/src/utils.ts
@@ -18,7 +18,7 @@ import {RefObject} from 'react';
 
 interface DroppableCollectionMap {
   id: string,
-  ref: RefObject<HTMLElement>
+  ref: RefObject<HTMLElement | null>
 }
 
 export const droppableCollectionMap = new WeakMap<DroppableCollectionState, DroppableCollectionMap>();
@@ -332,16 +332,16 @@ export function isDirectoryDropItem(dropItem: DropItem): dropItem is DirectoryDr
 // Global DnD collection state tracker.
 export interface DnDState {
   /** A ref for the  of the drag items in the current drag session if any. */
-  draggingCollectionRef?: RefObject<HTMLElement>,
+  draggingCollectionRef?: RefObject<HTMLElement | null>,
   /** The set of currently dragged keys. */
   draggingKeys: Set<Key>,
   /** A ref for the collection that is targeted for a drop operation, if any. */
-  dropCollectionRef?: RefObject<HTMLElement>
+  dropCollectionRef?: RefObject<HTMLElement | null>
 }
 
 export let globalDndState: DnDState = {draggingKeys: new Set()};
 
-export function setDraggingCollectionRef(ref: RefObject<HTMLElement>) {
+export function setDraggingCollectionRef(ref: RefObject<HTMLElement | null>) {
   globalDndState.draggingCollectionRef = ref;
 }
 
@@ -349,7 +349,7 @@ export function setDraggingKeys(keys: Set<Key>) {
   globalDndState.draggingKeys = keys;
 }
 
-export function setDropCollectionRef(ref: RefObject<HTMLElement>) {
+export function setDropCollectionRef(ref: RefObject<HTMLElement | null>) {
   globalDndState.dropCollectionRef = ref;
 }
 
@@ -363,7 +363,7 @@ export function setGlobalDnDState(state: DnDState) {
 
 // Util function to check if the current dragging collection ref is the same as the current targeted droppable collection ref.
 // Allows a droppable ref arg in case the global drop collection ref hasn't been set
-export function isInternalDropOperation(ref?: RefObject<HTMLElement>) {
+export function isInternalDropOperation(ref?: RefObject<HTMLElement | null>) {
   let {draggingCollectionRef, dropCollectionRef} = globalDndState;
   return draggingCollectionRef?.current != null && draggingCollectionRef.current === (ref?.current || dropCollectionRef?.current);
 }

--- a/packages/@react-aria/dnd/stories/DraggableCollection.tsx
+++ b/packages/@react-aria/dnd/stories/DraggableCollection.tsx
@@ -141,8 +141,8 @@ function DraggableCollection(props) {
 }
 
 function DraggableCollectionItem({item, state, dragState}) {
-  let rowRef = React.useRef();
-  let cellRef = React.useRef();
+  let rowRef = React.useRef(undefined);
+  let cellRef = React.useRef(undefined);
   let cellNode = [...item.childNodes][0];
   let isSelected = state.selectionManager.isSelected(item.key);
 
@@ -155,7 +155,7 @@ function DraggableCollectionItem({item, state, dragState}) {
 
   let {dragProps, dragButtonProps} = useDraggableItem({key: item.key, hasDragButton: true}, dragState);
 
-  let buttonRef = React.useRef();
+  let buttonRef = React.useRef(undefined);
   let {buttonProps} = useButton({
     ...dragButtonProps,
     elementType: 'div'

--- a/packages/@react-aria/dnd/stories/DraggableListBox.tsx
+++ b/packages/@react-aria/dnd/stories/DraggableListBox.tsx
@@ -10,7 +10,7 @@ import {useListState} from '@react-stately/list';
 
 export function DraggableListBox(props) {
   let state = useListState(props);
-  let ref = React.useRef();
+  let ref = React.useRef(undefined);
   let {listBoxProps} = useListBox(
     {
       ...props,
@@ -50,7 +50,7 @@ export function DraggableListBox(props) {
 }
 
 function Option({item, state, dragState}) {
-  let ref = React.useRef();
+  let ref = React.useRef(undefined);
   let {optionProps, isPressed, hasAction} = useOption(
     {key: item.key},
     state,

--- a/packages/@react-aria/dnd/stories/DroppableGrid.tsx
+++ b/packages/@react-aria/dnd/stories/DroppableGrid.tsx
@@ -183,7 +183,7 @@ const DroppableGrid = React.forwardRef(function (props: any, ref) {
   }, gridState, domRef);
 
   let isDropTarget = dropState.isDropTarget({type: 'root'});
-  let dropRef = React.useRef();
+  let dropRef = React.useRef(undefined);
   let {dropIndicatorProps} = useDropIndicator({
     target: {type: 'root'}
   }, dropState, dropRef);
@@ -233,8 +233,8 @@ const DroppableGrid = React.forwardRef(function (props: any, ref) {
 });
 
 function CollectionItem({item, state, dropState, onPaste}) {
-  let rowRef = React.useRef();
-  let cellRef = React.useRef();
+  let rowRef = React.useRef(undefined);
+  let cellRef = React.useRef(undefined);
   let cellNode = [...item.childNodes][0];
 
   let {rowProps} = useGridRow({node: item}, state, rowRef);
@@ -243,7 +243,7 @@ function CollectionItem({item, state, dropState, onPaste}) {
     focusMode: 'cell'
   }, state, cellRef);
 
-  let dropIndicatorRef = React.useRef();
+  let dropIndicatorRef = React.useRef(undefined);
   let {dropIndicatorProps} = useDropIndicator({
     target: {type: 'item', key: item.key, dropPosition: 'on'}
   }, dropState, dropIndicatorRef);
@@ -274,7 +274,7 @@ function CollectionItem({item, state, dropState, onPaste}) {
 }
 
 function InsertionIndicator(props) {
-  let ref = React.useRef();
+  let ref = React.useRef(undefined);
   let {dropIndicatorProps} = useDropIndicator(props, props.dropState, ref);
   let {visuallyHiddenProps} = useVisuallyHidden();
 

--- a/packages/@react-aria/dnd/stories/DroppableListBox.tsx
+++ b/packages/@react-aria/dnd/stories/DroppableListBox.tsx
@@ -134,7 +134,7 @@ export const DroppableListBox = React.forwardRef(function (props: any, ref) {
   }, state, domRef);
 
   let isDropTarget = dropState.isDropTarget({type: 'root'});
-  let dropRef = React.useRef();
+  let dropRef = React.useRef(undefined);
   let {dropIndicatorProps} = useDropIndicator({
     target: {type: 'root'}
   }, dropState, dropRef);
@@ -179,7 +179,7 @@ export const DroppableListBox = React.forwardRef(function (props: any, ref) {
 });
 
 function CollectionItem({item, state, dropState}) {
-  let ref = React.useRef();
+  let ref = React.useRef(undefined);
   let {optionProps} = useOption({
     key: item.key,
     isSelected: state.selectionManager.isSelected(item.key)
@@ -205,7 +205,7 @@ function CollectionItem({item, state, dropState}) {
 }
 
 function InsertionIndicator(props) {
-  let ref = React.useRef();
+  let ref = React.useRef(undefined);
   let {dropIndicatorProps} = useDropIndicator(props, props.dropState, ref);
 
   // If aria-hidden, we are either not in a drag session or the drop target is invalid.

--- a/packages/@react-aria/dnd/stories/Reorderable.tsx
+++ b/packages/@react-aria/dnd/stories/Reorderable.tsx
@@ -148,7 +148,7 @@ function ReorderableGrid(props) {
   }, gridState, ref);
 
   let isDropTarget = dropState.isDropTarget({type: 'root'});
-  let dropRef = React.useRef();
+  let dropRef = React.useRef(undefined);
   let {dropIndicatorProps} = useDropIndicator({
     target: {type: 'root'}
   }, dropState, dropRef);
@@ -211,8 +211,8 @@ function ReorderableGrid(props) {
 }
 
 function CollectionItem({item, state, dragState, dropState}) {
-  let rowRef = React.useRef();
-  let cellRef = React.useRef();
+  let rowRef = React.useRef(undefined);
+  let cellRef = React.useRef(undefined);
   let cellNode = [...item.childNodes][0];
 
   let {rowProps} = useGridRow({node: item}, state, rowRef);
@@ -224,13 +224,13 @@ function CollectionItem({item, state, dragState, dropState}) {
 
   let {dragProps, dragButtonProps} = useDraggableItem({key: item.key, hasDragButton: true}, dragState);
 
-  let dragButtonRef = React.useRef();
+  let dragButtonRef = React.useRef(undefined);
   let {buttonProps} = useButton({
     ...dragButtonProps,
     elementType: 'div'
   }, dragButtonRef);
 
-  let dropIndicatorRef = React.useRef();
+  let dropIndicatorRef = React.useRef(undefined);
   let {dropIndicatorProps} = useDropIndicator({
     target: {type: 'item', key: item.key, dropPosition: 'on'}
   }, dropState, dropIndicatorRef);
@@ -268,7 +268,7 @@ function CollectionItem({item, state, dragState, dropState}) {
 }
 
 function InsertionIndicator(props) {
-  let ref = React.useRef();
+  let ref = React.useRef(undefined);
   let {dropIndicatorProps} = useDropIndicator(props, props.dropState, ref);
   let {visuallyHiddenProps} = useVisuallyHidden();
 

--- a/packages/@react-aria/dnd/stories/VirtualizedListBox.tsx
+++ b/packages/@react-aria/dnd/stories/VirtualizedListBox.tsx
@@ -199,7 +199,7 @@ export const VirtualizedListBox = React.forwardRef(function (props: any, ref) {
 
 function CollectionItem({item}) {
   let {state, dropState} = React.useContext(Context);
-  let ref = React.useRef();
+  let ref = React.useRef(undefined);
   let {optionProps} = useOption({
     key: item.key,
     isSelected: state.selectionManager.isSelected(item.key),
@@ -228,7 +228,7 @@ function CollectionItem({item}) {
 
 function InsertionIndicator(props) {
   let {dropState} = React.useContext(Context);
-  let ref = React.useRef();
+  let ref = React.useRef(undefined);
   let {dropIndicatorProps} = useDropIndicator(props, dropState, ref);
 
   // If aria-hidden, we are either not in a drag session or the drop target is invalid.
@@ -260,7 +260,7 @@ function InsertionIndicator(props) {
 
 function RootDropIndicator() {
   let {dropState} = React.useContext(Context);
-  let dropRef = React.useRef();
+  let dropRef = React.useRef(undefined);
   let {dropIndicatorProps} = useDropIndicator({
     target: {type: 'root'}
   }, dropState, dropRef);

--- a/packages/@react-aria/dnd/stories/dnd.stories.tsx
+++ b/packages/@react-aria/dnd/stories/dnd.stories.tsx
@@ -273,7 +273,7 @@ export function Draggable() {
     }
   });
 
-  let ref = React.useRef();
+  let ref = React.useRef(undefined);
   let {buttonProps} = useButton({elementType: 'div'}, ref);
 
   return (
@@ -290,7 +290,7 @@ export function Draggable() {
 }
 
 export function Droppable({type, children, actionId = ''}: any) {
-  let ref = React.useRef();
+  let ref = React.useRef(undefined);
   let {dropProps, isDropTarget} = useDrop({
     ref,
     onDropEnter: action(`onDropEnter${actionId}`),
@@ -324,7 +324,7 @@ export function Droppable({type, children, actionId = ''}: any) {
 
 function DialogButton({children}) {
   let [isOpen, setOpen] = React.useState(false);
-  let ref = React.useRef();
+  let ref = React.useRef(undefined);
   let {dropProps, isDropTarget} = useDrop({
     ref: unwrapDOMRef(ref),
     onDropActivate() {
@@ -464,8 +464,8 @@ function DraggableCollection(props) {
 }
 
 function DraggableCollectionItem({item, state, dragState, onCut}) {
-  let rowRef = React.useRef();
-  let cellRef = React.useRef();
+  let rowRef = React.useRef(undefined);
+  let cellRef = React.useRef(undefined);
   let cellNode = [...item.childNodes][0];
   let isSelected = state.selectionManager.isSelected(item.key);
 
@@ -485,7 +485,7 @@ function DraggableCollectionItem({item, state, dragState, onCut}) {
     onCut: () => onCut(dragState.getKeysForDrag(item.key))
   });
 
-  let buttonRef = React.useRef();
+  let buttonRef = React.useRef(undefined);
   let {buttonProps} = useButton({
     ...dragButtonProps,
     elementType: 'div'

--- a/packages/@react-aria/focus/src/FocusScope.tsx
+++ b/packages/@react-aria/focus/src/FocusScope.tsx
@@ -58,7 +58,7 @@ export interface FocusManager {
   focusLast(opts?: FocusManagerOptions): FocusableElement | null
 }
 
-type ScopeRef = RefObject<Element[]> | null;
+type ScopeRef = RefObject<Element[] | null> | null;
 interface IFocusContext {
   focusManager: FocusManager,
   parentNode: TreeNode | null
@@ -192,7 +192,7 @@ export function useFocusManager(): FocusManager | undefined {
   return useContext(FocusContext)?.focusManager;
 }
 
-function createFocusManagerForScope(scopeRef: React.RefObject<Element[]>): FocusManager {
+function createFocusManagerForScope(scopeRef: React.RefObject<Element[] | null>): FocusManager {
   return {
     focusNext(opts: FocusManagerOptions = {}) {
       let scope = scopeRef.current!;
@@ -295,10 +295,10 @@ function shouldContainFocus(scopeRef: ScopeRef) {
   return true;
 }
 
-function useFocusContainment(scopeRef: RefObject<Element[]>, contain?: boolean) {
-  let focusedNode = useRef<FocusableElement>();
+function useFocusContainment(scopeRef: RefObject<Element[] | null>, contain?: boolean) {
+  let focusedNode = useRef<FocusableElement>(undefined);
 
-  let raf = useRef<ReturnType<typeof requestAnimationFrame>>();
+  let raf = useRef<ReturnType<typeof requestAnimationFrame>>(undefined);
   useLayoutEffect(() => {
     let scope = scopeRef.current;
     if (!contain) {
@@ -484,7 +484,7 @@ function focusFirstInScope(scope: Element[], tabbable:boolean = true) {
   focusElement(nextNode as FocusableElement);
 }
 
-function useAutoFocus(scopeRef: RefObject<Element[]>, autoFocus?: boolean) {
+function useAutoFocus(scopeRef: RefObject<Element[] | null>, autoFocus?: boolean) {
   const autoFocusRef = React.useRef(autoFocus);
   useEffect(() => {
     if (autoFocusRef.current) {
@@ -498,7 +498,7 @@ function useAutoFocus(scopeRef: RefObject<Element[]>, autoFocus?: boolean) {
   }, [scopeRef]);
 }
 
-function useActiveScopeTracker(scopeRef: RefObject<Element[]>, restore?: boolean, contain?: boolean) {
+function useActiveScopeTracker(scopeRef: RefObject<Element[] | null>, restore?: boolean, contain?: boolean) {
   // tracks the active scope, in case restore and contain are both false.
   // if either are true, this is tracked in useRestoreFocus or useFocusContainment.
   useLayoutEffect(() => {
@@ -540,7 +540,7 @@ function shouldRestoreFocus(scopeRef: ScopeRef) {
   return scope?.scopeRef === scopeRef;
 }
 
-function useRestoreFocus(scopeRef: RefObject<Element[]>, restoreFocus?: boolean, contain?: boolean) {
+function useRestoreFocus(scopeRef: RefObject<Element[] | null>, restoreFocus?: boolean, contain?: boolean) {
   // create a ref during render instead of useLayoutEffect so the active element is saved before a child with autoFocus=true mounts.
   // eslint-disable-next-line no-restricted-globals
   const nodeToRestoreRef = useRef(typeof document !== 'undefined' ? getOwnerDocument(scopeRef.current ? scopeRef.current[0] : undefined).activeElement as FocusableElement : null);
@@ -675,8 +675,7 @@ function useRestoreFocus(scopeRef: RefObject<Element[]>, restoreFocus?: boolean,
         && nodeToRestore
         && (
           // eslint-disable-next-line react-hooks/exhaustive-deps
-          isElementInScope(ownerDocument.activeElement, scopeRef.current)
-          || (ownerDocument.activeElement === ownerDocument.body && shouldRestoreFocus(scopeRef))
+          (isElementInScope(ownerDocument.activeElement, scopeRef.current) || (ownerDocument.activeElement === ownerDocument.body && shouldRestoreFocus(scopeRef)))
         )
       ) {
         // freeze the focusScopeTree so it persists after the raf, otherwise during unmount nodes are removed from it
@@ -750,7 +749,7 @@ export function getFocusableTreeWalker(root: Element, opts?: FocusManagerOptions
 /**
  * Creates a FocusManager object that can be used to move focus within an element.
  */
-export function createFocusManager(ref: RefObject<Element>, defaultOptions: FocusManagerOptions = {}): FocusManager {
+export function createFocusManager(ref: RefObject<Element | null>, defaultOptions: FocusManagerOptions = {}): FocusManager {
   return {
     focusNext(opts: FocusManagerOptions = {}) {
       let root = ref.current;

--- a/packages/@react-aria/focus/src/useFocusable.tsx
+++ b/packages/@react-aria/focus/src/useFocusable.tsx
@@ -32,7 +32,7 @@ interface FocusableContextValue extends FocusableProviderProps {
 
 let FocusableContext = React.createContext<FocusableContextValue | null>(null);
 
-function useFocusableContext(ref: RefObject<FocusableElement>): FocusableContextValue {
+function useFocusableContext(ref: RefObject<FocusableElement | null>): FocusableContextValue {
   let context = useContext(FocusableContext) || {};
   useSyncRef(context, ref);
 
@@ -70,7 +70,7 @@ export interface FocusableAria {
 /**
  * Used to make an element focusable and capable of auto focus.
  */
-export function useFocusable(props: FocusableOptions, domRef: RefObject<FocusableElement>): FocusableAria {
+export function useFocusable(props: FocusableOptions, domRef: RefObject<FocusableElement | null>): FocusableAria {
   let {focusProps} = useFocus(props);
   let {keyboardProps} = useKeyboard(props);
   let interactions = mergeProps(focusProps, keyboardProps);

--- a/packages/@react-aria/focus/src/useHasTabbableChild.ts
+++ b/packages/@react-aria/focus/src/useHasTabbableChild.ts
@@ -27,7 +27,7 @@ interface AriaHasTabbableChildOptions {
  * Returns whether an element has a tabbable child, and updates as children change.
  * @private
  */
-export function useHasTabbableChild(ref: RefObject<Element>, options?: AriaHasTabbableChildOptions): boolean {
+export function useHasTabbableChild(ref: RefObject<Element | null>, options?: AriaHasTabbableChildOptions): boolean {
   let isDisabled = options?.isDisabled;
   let [hasTabbableChild, setHasTabbableChild] = useState(false);
 

--- a/packages/@react-aria/form/src/useFormValidation.ts
+++ b/packages/@react-aria/form/src/useFormValidation.ts
@@ -22,7 +22,7 @@ interface FormValidationProps<T> extends Validation<T> {
   focus?: () => void
 }
 
-export function useFormValidation<T>(props: FormValidationProps<T>, state: FormValidationState, ref: RefObject<ValidatableElement> | undefined) {
+export function useFormValidation<T>(props: FormValidationProps<T>, state: FormValidationState, ref: RefObject<ValidatableElement | null> | undefined) {
   let {validationBehavior, focus} = props;
 
   // This is a useLayoutEffect so that it runs before the useEffect in useFormValidationState, which commits the validation change.

--- a/packages/@react-aria/grid/src/GridKeyboardDelegate.ts
+++ b/packages/@react-aria/grid/src/GridKeyboardDelegate.ts
@@ -19,7 +19,7 @@ import {RefObject} from 'react';
 export interface GridKeyboardDelegateOptions<T, C> {
   collection: C,
   disabledKeys: Set<Key>,
-  ref?: RefObject<HTMLElement>,
+  ref?: RefObject<HTMLElement | null>,
   direction: Direction,
   collator?: Intl.Collator,
   layout?: Layout<Node<T>>,
@@ -29,7 +29,7 @@ export interface GridKeyboardDelegateOptions<T, C> {
 export class GridKeyboardDelegate<T, C extends GridCollection<T>> implements KeyboardDelegate {
   collection: C;
   protected disabledKeys: Set<Key>;
-  protected ref: RefObject<HTMLElement>;
+  protected ref: RefObject<HTMLElement | null>;
   protected direction: Direction;
   protected collator: Intl.Collator;
   protected layout: Layout<Node<T>>;

--- a/packages/@react-aria/grid/src/useGrid.ts
+++ b/packages/@react-aria/grid/src/useGrid.ts
@@ -44,7 +44,7 @@ export interface GridProps extends DOMProps, AriaLabelingProps {
   /**
    * The ref attached to the scrollable body. Used to provided automatic scrolling on item focus for non-virtualized grids.
    */
-  scrollRef?: RefObject<HTMLElement>,
+  scrollRef?: RefObject<HTMLElement | null>,
   /** Handler that is called when a user performs an action on the row. */
   onRowAction?: (key: Key) => void,
   /** Handler that is called when a user performs an action on the cell. */
@@ -63,7 +63,7 @@ export interface GridAria {
  * @param state - State for the grid, as returned by `useGridState`.
  * @param ref - The ref attached to the grid element.
  */
-export function useGrid<T>(props: GridProps, state: GridState<T, GridCollection<T>>, ref: RefObject<HTMLElement>): GridAria {
+export function useGrid<T>(props: GridProps, state: GridState<T, GridCollection<T>>, ref: RefObject<HTMLElement | null>): GridAria {
   let {
     isVirtualized,
     keyboardDelegate,

--- a/packages/@react-aria/grid/src/useGridCell.ts
+++ b/packages/@react-aria/grid/src/useGridCell.ts
@@ -50,7 +50,7 @@ export interface GridCellAria {
  * @param props - Props for the cell.
  * @param state - State of the parent grid, as returned by `useGridState`.
  */
-export function useGridCell<T, C extends GridCollection<T>>(props: GridCellProps, state: GridState<T, C>, ref: RefObject<FocusableElement>): GridCellAria {
+export function useGridCell<T, C extends GridCollection<T>>(props: GridCellProps, state: GridState<T, C>, ref: RefObject<FocusableElement | null>): GridCellAria {
   let {
     node,
     isVirtualized,

--- a/packages/@react-aria/grid/src/useGridRow.ts
+++ b/packages/@react-aria/grid/src/useGridRow.ts
@@ -44,7 +44,7 @@ export interface GridRowAria extends SelectableItemStates {
  * @param props - Props for the row.
  * @param state - State of the parent grid, as returned by `useGridState`.
  */
-export function useGridRow<T, C extends GridCollection<T>, S extends GridState<T, C>>(props: GridRowProps<T>, state: S, ref: RefObject<FocusableElement>): GridRowAria {
+export function useGridRow<T, C extends GridCollection<T>, S extends GridState<T, C>>(props: GridRowProps<T>, state: S, ref: RefObject<FocusableElement | null>): GridRowAria {
   let {
     node,
     isVirtualized,

--- a/packages/@react-aria/grid/stories/example.tsx
+++ b/packages/@react-aria/grid/stories/example.tsx
@@ -24,7 +24,7 @@ export function Grid(props) {
     })
   });
 
-  let ref = React.useRef();
+  let ref = React.useRef(undefined);
   let {gridProps} = useGrid({
     'aria-label': 'Grid',
     focusMode: gridFocusMode
@@ -44,8 +44,8 @@ export function Grid(props) {
 }
 
 function Row({state, item, focusMode}) {
-  let rowRef = React.useRef();
-  let cellRef = React.useRef();
+  let rowRef = React.useRef(undefined);
+  let cellRef = React.useRef(undefined);
   let cellNode = [...item.childNodes][0];
   let {rowProps} = useGridRow({node: item}, state, rowRef);
   let {gridCellProps} = useGridCell({

--- a/packages/@react-aria/gridlist/src/useGridList.ts
+++ b/packages/@react-aria/gridlist/src/useGridList.ts
@@ -75,7 +75,7 @@ export interface GridListAria {
  * @param state - State for the list, as returned by `useListState`.
  * @param ref - The ref attached to the list element.
  */
-export function useGridList<T>(props: AriaGridListOptions<T>, state: ListState<T>, ref: RefObject<HTMLElement>): GridListAria {
+export function useGridList<T>(props: AriaGridListOptions<T>, state: ListState<T>, ref: RefObject<HTMLElement | null>): GridListAria {
   let {
     isVirtualized,
     keyboardDelegate,

--- a/packages/@react-aria/gridlist/src/useGridListItem.ts
+++ b/packages/@react-aria/gridlist/src/useGridListItem.ts
@@ -57,7 +57,7 @@ const EXPANSION_KEYS = {
  * @param state - State of the parent list, as returned by `useListState`.
  * @param ref - The ref attached to the row element.
  */
-export function useGridListItem<T>(props: AriaGridListItemOptions, state: ListState<T> | TreeState<T>, ref: RefObject<FocusableElement>): GridListItemAria {
+export function useGridListItem<T>(props: AriaGridListItemOptions, state: ListState<T> | TreeState<T>, ref: RefObject<FocusableElement | null>): GridListItemAria {
   // Copied from useGridCell + some modifications to make it not so grid specific
   let {
     node,

--- a/packages/@react-aria/interactions/src/DOMPropsContext.ts
+++ b/packages/@react-aria/interactions/src/DOMPropsContext.ts
@@ -15,7 +15,7 @@ import {mergeProps, useSyncRef} from '@react-aria/utils';
 import React, {MutableRefObject, RefObject, useContext} from 'react';
 
 interface DOMPropsResponderProps extends DOMAttributes {
-  ref?: RefObject<Element>
+  ref?: RefObject<Element | null>
 }
 
 interface IDOMPropsResponderContext extends DOMAttributes {

--- a/packages/@react-aria/interactions/src/useDOMPropsResponder.ts
+++ b/packages/@react-aria/interactions/src/useDOMPropsResponder.ts
@@ -13,7 +13,7 @@
 import {RefObject} from 'react';
 import {useDOMPropsResponderContext} from './DOMPropsContext';
 
-export function useDOMPropsResponder(domRef: RefObject<Element>) {
+export function useDOMPropsResponder(domRef: RefObject<Element | null>) {
 
   let domProps = useDOMPropsResponderContext({ref: domRef}) || {};
 

--- a/packages/@react-aria/interactions/src/useInteractOutside.ts
+++ b/packages/@react-aria/interactions/src/useInteractOutside.ts
@@ -19,7 +19,7 @@ import {getOwnerDocument, useEffectEvent} from '@react-aria/utils';
 import {RefObject, useEffect, useRef} from 'react';
 
 export interface InteractOutsideProps {
-  ref: RefObject<Element>,
+  ref: RefObject<Element | null>,
   onInteractOutside?: (e: PointerEvent) => void,
   onInteractOutsideStart?: (e: PointerEvent) => void,
   /** Whether the interact outside events should be disabled. */

--- a/packages/@react-aria/interactions/src/useLongPress.ts
+++ b/packages/@react-aria/interactions/src/useLongPress.ts
@@ -63,7 +63,7 @@ export function useLongPress(props: LongPressProps): LongPressResult {
     accessibilityDescription
   } = props;
 
-  const timeRef = useRef<ReturnType<typeof setTimeout> | undefined>();
+  const timeRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   let {addGlobalListener, removeGlobalListener} = useGlobalListeners();
 
   let {pressProps} = usePress({

--- a/packages/@react-aria/interactions/src/usePress.ts
+++ b/packages/@react-aria/interactions/src/usePress.ts
@@ -41,7 +41,7 @@ export interface PressProps extends PressEvents {
 
 export interface PressHookProps extends PressProps {
   /** A ref to the target element. */
-  ref?: RefObject<Element>
+  ref?: RefObject<Element | null>
 }
 
 interface PressState {

--- a/packages/@react-aria/interactions/src/useScrollWheel.ts
+++ b/packages/@react-aria/interactions/src/useScrollWheel.ts
@@ -20,7 +20,7 @@ export interface ScrollWheelProps extends ScrollEvents {
 }
 
 // scroll wheel needs to be added not passively so it's cancelable, small helper hook to remember that
-export function useScrollWheel(props: ScrollWheelProps, ref: RefObject<HTMLElement>): void {
+export function useScrollWheel(props: ScrollWheelProps, ref: RefObject<HTMLElement | null>): void {
   let {onScroll, isDisabled} = props;
   let onScrollHandler = useCallback((e) => {
     // If the ctrlKey is pressed, this is a zoom event, do nothing.

--- a/packages/@react-aria/interactions/stories/useFocusRing.stories.tsx
+++ b/packages/@react-aria/interactions/stories/useFocusRing.stories.tsx
@@ -125,6 +125,7 @@ const IframeWrapper = ({children}) => {
       if (iframeDocument) {
         iframeDocument.body.innerHTML = '';
         iframeDocument.body.appendChild(main);
+        // @ts-expect-error FIXME: `render()` was removed in React 19
         ReactDOM.render(children, main);
 
         return addWindowFocusTracking(iframeDocument.body);

--- a/packages/@react-aria/interactions/stories/useMove.stories.tsx
+++ b/packages/@react-aria/interactions/stories/useMove.stories.tsx
@@ -33,7 +33,7 @@ interface ClampedMoveProps {
 }
 
 function useClampedMove(props: ClampedMoveProps) {
-  let currentPosition = useRef<IPosition | null>();
+  let currentPosition = useRef<IPosition | null>(undefined);
 
   let {getCurrentState, onMoveTo, onMoveStart, onMoveEnd, reverseX = false, reverseY = false} = props;
 

--- a/packages/@react-aria/landmark/src/useLandmark.ts
+++ b/packages/@react-aria/landmark/src/useLandmark.ts
@@ -44,7 +44,7 @@ interface LandmarkManagerApi {
 // from an older version of useLandmark against a newer version of
 // LandmarkManager does not crash.
 interface Landmark {
-  ref: RefObject<FocusableElement>,
+  ref: RefObject<FocusableElement | null>,
   role: AriaLandmarkRole,
   label?: string,
   lastFocused?: FocusableElement,
@@ -203,7 +203,7 @@ class LandmarkManager implements LandmarkManagerApi {
     }
   }
 
-  private removeLandmark(ref: RefObject<Element>) {
+  private removeLandmark(ref: RefObject<Element | null>) {
     this.landmarks = this.landmarks.filter(landmark => landmark.ref !== ref);
     this.teardownIfNeeded();
   }
@@ -477,7 +477,7 @@ export function createLandmarkController(): LandmarkController {
  * @param props - Props for the landmark.
  * @param ref - Ref to the landmark.
  */
-export function useLandmark(props: AriaLandmarkProps, ref: RefObject<FocusableElement>): LandmarkAria {
+export function useLandmark(props: AriaLandmarkProps, ref: RefObject<FocusableElement | null>): LandmarkAria {
   const {
     role,
     'aria-label': ariaLabel,

--- a/packages/@react-aria/link/src/useLink.ts
+++ b/packages/@react-aria/link/src/useLink.ts
@@ -39,7 +39,7 @@ export interface LinkAria {
  * A link allows a user to navigate to another page or resource within a web page
  * or application.
  */
-export function useLink(props: AriaLinkOptions, ref: RefObject<FocusableElement>): LinkAria {
+export function useLink(props: AriaLinkOptions, ref: RefObject<FocusableElement | null>): LinkAria {
   let {
     elementType = 'a',
     onPress,

--- a/packages/@react-aria/listbox/src/useListBox.ts
+++ b/packages/@react-aria/listbox/src/useListBox.ts
@@ -64,7 +64,7 @@ export interface AriaListBoxOptions<T> extends Omit<AriaListBoxProps<T>, 'childr
  * @param props - Props for the listbox.
  * @param state - State for the listbox, as returned by `useListState`.
  */
-export function useListBox<T>(props: AriaListBoxOptions<T>, state: ListState<T>, ref: RefObject<HTMLElement>): ListBoxAria {
+export function useListBox<T>(props: AriaListBoxOptions<T>, state: ListState<T>, ref: RefObject<HTMLElement | null>): ListBoxAria {
   let domProps = filterDOMProps(props, {labelable: true});
   // Use props instead of state here. We don't want this to change due to long press.
   let selectionBehavior = props.selectionBehavior || 'toggle';

--- a/packages/@react-aria/listbox/src/useOption.ts
+++ b/packages/@react-aria/listbox/src/useOption.ts
@@ -86,7 +86,7 @@ export interface AriaOptionProps {
  * @param props - Props for the option.
  * @param state - State for the listbox, as returned by `useListState`.
  */
-export function useOption<T>(props: AriaOptionProps, state: ListState<T>, ref: RefObject<FocusableElement>): OptionAria {
+export function useOption<T>(props: AriaOptionProps, state: ListState<T>, ref: RefObject<FocusableElement | null>): OptionAria {
   let {
     key
   } = props;

--- a/packages/@react-aria/menu/src/useMenu.ts
+++ b/packages/@react-aria/menu/src/useMenu.ts
@@ -46,7 +46,7 @@ export const menuData = new WeakMap<TreeState<unknown>, MenuData>();
  * @param props - Props for the menu.
  * @param state - State for the menu, as returned by `useListState`.
  */
-export function useMenu<T>(props: AriaMenuOptions<T>, state: TreeState<T>, ref: RefObject<HTMLElement>): MenuAria {
+export function useMenu<T>(props: AriaMenuOptions<T>, state: TreeState<T>, ref: RefObject<HTMLElement | null>): MenuAria {
   let {
     shouldFocusWrap = true,
     onKeyDown,

--- a/packages/@react-aria/menu/src/useMenuItem.ts
+++ b/packages/@react-aria/menu/src/useMenuItem.ts
@@ -98,7 +98,7 @@ export interface AriaMenuItemProps extends DOMProps, PressEvents, HoverEvents, K
  * @param props - Props for the item.
  * @param state - State for the menu, as returned by `useTreeState`.
  */
-export function useMenuItem<T>(props: AriaMenuItemProps, state: TreeState<T>, ref: RefObject<FocusableElement>): MenuItemAria {
+export function useMenuItem<T>(props: AriaMenuItemProps, state: TreeState<T>, ref: RefObject<FocusableElement | null>): MenuItemAria {
   let {
     key,
     closeOnSelect,

--- a/packages/@react-aria/menu/src/useMenuTrigger.ts
+++ b/packages/@react-aria/menu/src/useMenuTrigger.ts
@@ -45,7 +45,7 @@ export interface MenuTriggerAria<T> {
  * @param state - State for the menu trigger.
  * @param ref - Ref to the HTML element trigger for the menu.
  */
-export function useMenuTrigger<T>(props: AriaMenuTriggerProps, state: MenuTriggerState, ref: RefObject<Element>): MenuTriggerAria<T> {
+export function useMenuTrigger<T>(props: AriaMenuTriggerProps, state: MenuTriggerState, ref: RefObject<Element | null>): MenuTriggerAria<T> {
   let {
     type = 'menu' as AriaMenuTriggerProps['type'],
     isDisabled,

--- a/packages/@react-aria/menu/src/useSafelyMouseToSubmenu.ts
+++ b/packages/@react-aria/menu/src/useSafelyMouseToSubmenu.ts
@@ -4,9 +4,9 @@ import {useResizeObserver} from '@react-aria/utils';
 
 interface SafelyMouseToSubmenuOptions {
   /** Ref for the parent menu. */
-  menuRef: RefObject<Element>,
+  menuRef: RefObject<Element | null>,
   /** Ref for the submenu. */
-  submenuRef: RefObject<Element>,
+  submenuRef: RefObject<Element | null>,
   /** Whether the submenu is open. */
   isOpen: boolean,
   /** Whether this feature is disabled. */
@@ -24,12 +24,12 @@ const ANGLE_PADDING = Math.PI / 12; // 15°
  */
 export function useSafelyMouseToSubmenu(options: SafelyMouseToSubmenuOptions) {
   let {menuRef, submenuRef, isOpen, isDisabled} = options;
-  let prevPointerPos = useRef<{x: number, y: number} | undefined>();
-  let submenuRect = useRef<DOMRect | undefined>();
+  let prevPointerPos = useRef<{x: number, y: number} | undefined>(undefined);
+  let submenuRect = useRef<DOMRect | undefined>(undefined);
   let lastProcessedTime = useRef<number>(0);
-  let timeout = useRef<ReturnType<typeof setTimeout> | undefined>();
-  let autoCloseTimeout = useRef<ReturnType<typeof setTimeout> | undefined>();
-  let submenuSide = useRef<'left' | 'right' | undefined>();
+  let timeout = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  let autoCloseTimeout = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  let submenuSide = useRef<'left' | 'right' | undefined>(undefined);
   let movementsTowardsSubmenuCount = useRef<number>(2);
   let [preventPointerEvents, setPreventPointerEvents] = useState(false);
 

--- a/packages/@react-aria/menu/src/useSubmenuTrigger.ts
+++ b/packages/@react-aria/menu/src/useSubmenuTrigger.ts
@@ -28,9 +28,9 @@ export interface AriaSubmenuTriggerProps {
   /** The type of the contents that the submenu trigger opens. */
   type?: 'dialog' | 'menu',
   /** Ref of the menu that contains the submenu trigger. */
-  parentMenuRef: RefObject<HTMLElement>,
+  parentMenuRef: RefObject<HTMLElement | null>,
   /** Ref of the submenu opened by the submenu trigger. */
-  submenuRef: RefObject<HTMLElement>,
+  submenuRef: RefObject<HTMLElement | null>,
   /**
    * The delay time in milliseconds for the submenu to appear after hovering over the trigger.
    * @default 200
@@ -63,12 +63,12 @@ export interface SubmenuTriggerAria<T> {
  * @param state - State for the submenu trigger.
  * @param ref - Ref to the submenu trigger element.
  */
-export function UNSTABLE_useSubmenuTrigger<T>(props: AriaSubmenuTriggerProps, state: SubmenuTriggerState, ref: RefObject<FocusableElement>): SubmenuTriggerAria<T> {
+export function UNSTABLE_useSubmenuTrigger<T>(props: AriaSubmenuTriggerProps, state: SubmenuTriggerState, ref: RefObject<FocusableElement | null>): SubmenuTriggerAria<T> {
   let {parentMenuRef, submenuRef, type = 'menu', isDisabled, node, delay = 200} = props;
   let submenuTriggerId = useId();
   let overlayId = useId();
   let {direction} = useLocale();
-  let openTimeout = useRef<ReturnType<typeof setTimeout> | undefined>();
+  let openTimeout = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   let cancelOpenTimeout = useCallback(() => {
     if (openTimeout.current) {
       clearTimeout(openTimeout.current);

--- a/packages/@react-aria/menu/stories/useMenu.stories.tsx
+++ b/packages/@react-aria/menu/stories/useMenu.stories.tsx
@@ -54,7 +54,7 @@ function MenuButton(props) {
   let state = useMenuTriggerState(props);
 
   // Get props for the menu trigger and menu elements
-  let ref = React.useRef();
+  let ref = React.useRef(undefined);
   let {menuTriggerProps, menuProps} = useMenuTrigger({}, state, ref);
 
   // Get props for the button based on the trigger props from useMenuTrigger
@@ -84,12 +84,12 @@ function MenuPopup(props) {
   let state = useTreeState({...props, selectionMode: 'none'});
 
   // Get props for the menu element
-  let ref = React.useRef();
+  let ref = React.useRef(undefined);
   let {menuProps} = useMenu(props, state, ref);
 
   // Handle events that should cause the menu to close,
   // e.g. blur, clicking outside, or pressing the escape key.
-  let overlayRef = React.useRef();
+  let overlayRef = React.useRef(undefined);
   // before useOverlay so this action will get called
   useInteractOutside({ref: overlayRef, onInteractOutside: action('onInteractOutside')});
   let {overlayProps} = useOverlay(
@@ -139,7 +139,7 @@ function MenuPopup(props) {
 
 function MenuItem({item, state, onAction, onClose}) {
   // Get props for the menu item element
-  let ref = React.useRef();
+  let ref = React.useRef(undefined);
   let {menuItemProps} = useMenuItem(
     {
       key: item.key,

--- a/packages/@react-aria/numberfield/src/useNumberField.ts
+++ b/packages/@react-aria/numberfield/src/useNumberField.ts
@@ -55,7 +55,7 @@ export interface NumberFieldAria extends ValidationResult {
  * Provides the behavior and accessibility implementation for a number field component.
  * Number fields allow users to enter a number, and increment or decrement the value using stepper buttons.
  */
-export function useNumberField(props: AriaNumberFieldProps, state: NumberFieldState, inputRef: RefObject<HTMLInputElement>): NumberFieldAria {
+export function useNumberField(props: AriaNumberFieldProps, state: NumberFieldState, inputRef: RefObject<HTMLInputElement | null>): NumberFieldAria {
   let {
     id,
     decrementAriaLabel,

--- a/packages/@react-aria/overlays/src/useCloseOnScroll.ts
+++ b/packages/@react-aria/overlays/src/useCloseOnScroll.ts
@@ -20,7 +20,7 @@ import {RefObject, useEffect} from 'react';
 export const onCloseMap: WeakMap<Element, () => void> = new WeakMap();
 
 interface CloseOnScrollOptions {
-  triggerRef: RefObject<Element>,
+  triggerRef: RefObject<Element | null>,
   isOpen?: boolean,
   onClose?: () => void
 }

--- a/packages/@react-aria/overlays/src/useModalOverlay.ts
+++ b/packages/@react-aria/overlays/src/useModalOverlay.ts
@@ -43,7 +43,7 @@ export interface ModalOverlayAria {
  * Provides the behavior and accessibility implementation for a modal component.
  * A modal is an overlay element which blocks interaction with elements outside it.
  */
-export function useModalOverlay(props: AriaModalOverlayProps, state: OverlayTriggerState, ref: RefObject<HTMLElement>): ModalOverlayAria {
+export function useModalOverlay(props: AriaModalOverlayProps, state: OverlayTriggerState, ref: RefObject<HTMLElement | null>): ModalOverlayAria {
   let {overlayProps, underlayProps} = useOverlay({
     ...props,
     isOpen: state.isOpen,

--- a/packages/@react-aria/overlays/src/useOverlay.ts
+++ b/packages/@react-aria/overlays/src/useOverlay.ts
@@ -53,14 +53,14 @@ export interface OverlayAria {
   underlayProps: DOMAttributes
 }
 
-const visibleOverlays: RefObject<Element>[] = [];
+const visibleOverlays: RefObject<Element | null>[] = [];
 
 /**
  * Provides the behavior for overlays such as dialogs, popovers, and menus.
  * Hides the overlay when the user interacts outside it, when the Escape key is pressed,
  * or optionally, on blur. Only the top-most overlay will close at once.
  */
-export function useOverlay(props: AriaOverlayProps, ref: RefObject<Element>): OverlayAria {
+export function useOverlay(props: AriaOverlayProps, ref: RefObject<Element | null>): OverlayAria {
   let {
     onClose,
     shouldCloseOnBlur,

--- a/packages/@react-aria/overlays/src/useOverlayPosition.ts
+++ b/packages/@react-aria/overlays/src/useOverlayPosition.ts
@@ -32,16 +32,16 @@ export interface AriaPositionProps extends PositionProps {
   /**
    * The ref for the element which the overlay positions itself with respect to.
    */
-  targetRef: RefObject<Element>,
+  targetRef: RefObject<Element | null>,
   /**
    * The ref for the overlay element.
    */
-  overlayRef: RefObject<Element>,
+  overlayRef: RefObject<Element | null>,
   /**
    * A ref for the scrollable region within the overlay.
    * @default overlayRef
    */
-  scrollRef?: RefObject<Element>,
+  scrollRef?: RefObject<Element | null>,
   /**
    * Whether the overlay should update its position automatically.
    * @default true

--- a/packages/@react-aria/overlays/src/useOverlayTrigger.ts
+++ b/packages/@react-aria/overlays/src/useOverlayTrigger.ts
@@ -34,7 +34,7 @@ export interface OverlayTriggerAria {
  * Handles the behavior and accessibility for an overlay trigger, e.g. a button
  * that opens a popover, menu, or other overlay that is positioned relative to the trigger.
  */
-export function useOverlayTrigger(props: OverlayTriggerProps, state: OverlayTriggerState, ref?: RefObject<Element>): OverlayTriggerAria {
+export function useOverlayTrigger(props: OverlayTriggerProps, state: OverlayTriggerState, ref?: RefObject<Element | null>): OverlayTriggerAria {
   let {type} = props;
   let {isOpen} = state;
 

--- a/packages/@react-aria/overlays/src/usePopover.ts
+++ b/packages/@react-aria/overlays/src/usePopover.ts
@@ -24,11 +24,11 @@ export interface AriaPopoverProps extends Omit<AriaPositionProps, 'isOpen' | 'on
   /**
    * The ref for the element which the popover positions itself with respect to.
    */
-  triggerRef: RefObject<Element>,
+  triggerRef: RefObject<Element | null>,
   /**
    * The ref for the popover element.
    */
-  popoverRef: RefObject<Element>,
+  popoverRef: RefObject<Element | null>,
   /**
    * Whether the popover is non-modal, i.e. elements outside the popover may be
    * interacted with by assistive technologies.

--- a/packages/@react-aria/overlays/test/useOverlayPosition.test.tsx
+++ b/packages/@react-aria/overlays/test/useOverlayPosition.test.tsx
@@ -15,9 +15,9 @@ import React, {useRef} from 'react';
 import {useOverlayPosition} from '../';
 
 function Example({triggerTop = 250, ...props}) {
-  let targetRef = useRef();
-  let containerRef = useRef();
-  let overlayRef = useRef();
+  let targetRef = useRef(undefined);
+  let containerRef = useRef(undefined);
+  let overlayRef = useRef(undefined);
   let {overlayProps, placement, arrowProps} = useOverlayPosition({targetRef, overlayRef, arrowSize: 8, ...props});
   let style = {width: 300, height: 200, ...overlayProps.style};
   return (

--- a/packages/@react-aria/radio/src/useRadio.ts
+++ b/packages/@react-aria/radio/src/useRadio.ts
@@ -39,7 +39,7 @@ export interface RadioAria {
  * @param state - State for the radio group, as returned by `useRadioGroupState`.
  * @param ref - Ref to the HTML input element.
  */
-export function useRadio(props: AriaRadioProps, state: RadioGroupState, ref: RefObject<HTMLInputElement>): RadioAria {
+export function useRadio(props: AriaRadioProps, state: RadioGroupState, ref: RefObject<HTMLInputElement | null>): RadioAria {
   let {
     value,
     children,

--- a/packages/@react-aria/searchfield/src/useSearchField.ts
+++ b/packages/@react-aria/searchfield/src/useSearchField.ts
@@ -43,7 +43,7 @@ export interface SearchFieldAria extends ValidationResult {
 export function useSearchField(
   props: AriaSearchFieldProps,
   state: SearchFieldState,
-  inputRef: RefObject<HTMLInputElement>
+  inputRef: RefObject<HTMLInputElement | null>
 ): SearchFieldAria {
   let stringFormatter = useLocalizedStringFormatter(intlMessages, '@react-aria/searchfield');
   let {

--- a/packages/@react-aria/select/src/HiddenSelect.tsx
+++ b/packages/@react-aria/select/src/HiddenSelect.tsx
@@ -40,12 +40,12 @@ export interface HiddenSelectProps<T> extends AriaHiddenSelectProps {
   state: SelectState<T>,
 
   /** A ref to the trigger element. */
-  triggerRef: RefObject<FocusableElement>
+  triggerRef: RefObject<FocusableElement | null>
 }
 
 export interface AriaHiddenSelectOptions extends AriaHiddenSelectProps {
   /** A ref to the hidden `<select>` element. */
-  selectRef?: RefObject<HTMLSelectElement>
+  selectRef?: RefObject<HTMLSelectElement | null>
 }
 
 /**
@@ -53,7 +53,7 @@ export interface AriaHiddenSelectOptions extends AriaHiddenSelectProps {
  * can be used in combination with `useSelect` to support browser form autofill, mobile form
  * navigation, and native HTML form submission.
  */
-export function useHiddenSelect<T>(props: AriaHiddenSelectOptions, state: SelectState<T>, triggerRef: RefObject<FocusableElement>) {
+export function useHiddenSelect<T>(props: AriaHiddenSelectOptions, state: SelectState<T>, triggerRef: RefObject<FocusableElement | null>) {
   let data = selectData.get(state) || {};
   let {autoComplete, name = data.name, isDisabled = data.isDisabled} = props;
   let {validationBehavior, isRequired} = data;

--- a/packages/@react-aria/select/src/useSelect.ts
+++ b/packages/@react-aria/select/src/useSelect.ts
@@ -66,7 +66,7 @@ export const selectData = new WeakMap<SelectState<any>, SelectData>();
  * @param props - Props for the select.
  * @param state - State for the select, as returned by `useListState`.
  */
-export function useSelect<T>(props: AriaSelectOptions<T>, state: SelectState<T>, ref: RefObject<FocusableElement>): SelectAria<T> {
+export function useSelect<T>(props: AriaSelectOptions<T>, state: SelectState<T>, ref: RefObject<FocusableElement | null>): SelectAria<T> {
   let {
     keyboardDelegate,
     isDisabled,

--- a/packages/@react-aria/select/stories/example.tsx
+++ b/packages/@react-aria/select/stories/example.tsx
@@ -23,7 +23,7 @@ export function Select(props) {
   let state = useSelectState(props);
 
   // Get props for child elements from useSelect
-  let ref = React.useRef();
+  let ref = React.useRef(undefined);
   let {
     labelProps,
     triggerProps,
@@ -70,7 +70,7 @@ export function Select(props) {
 }
 
 function Popover(props) {
-  let ref = React.useRef();
+  let ref = React.useRef(undefined);
   let {
     popoverRef = ref,
     isOpen,
@@ -110,7 +110,7 @@ function Popover(props) {
 
 
 function ListBox(props) {
-  let ref = React.useRef();
+  let ref = React.useRef(undefined);
   let {listBoxRef = ref, state} = props;
   let {listBoxProps} = useListBox(props, state, listBoxRef);
 
@@ -136,7 +136,7 @@ function ListBox(props) {
 }
 
 function Option({item, state}) {
-  let ref = React.useRef();
+  let ref = React.useRef(undefined);
   let {optionProps, isSelected, isFocused, isDisabled} = useOption({key: item.key}, state, ref);
 
   let backgroundColor;

--- a/packages/@react-aria/select/test/HiddenSelect.test.tsx
+++ b/packages/@react-aria/select/test/HiddenSelect.test.tsx
@@ -7,7 +7,7 @@ import {SelectProps, useSelectState} from '@react-stately/select';
 import userEvent from '@testing-library/user-event';
 
 const HiddenSelectExample = (props: Partial<SelectProps<{ key: number, value: string }>> & { hiddenProps?: Partial<HiddenSelectProps<any>> }) => {
-  const triggerRef = useRef();
+  const triggerRef = useRef(undefined);
   const state = useSelectState({
     children: (item) => (
       <Item>{item.value}</Item>

--- a/packages/@react-aria/selection/src/ListKeyboardDelegate.ts
+++ b/packages/@react-aria/selection/src/ListKeyboardDelegate.ts
@@ -16,7 +16,7 @@ import {RefObject} from 'react';
 
 interface ListKeyboardDelegateOptions<T> {
   collection: Collection<Node<T>>,
-  ref: RefObject<HTMLElement>,
+  ref: RefObject<HTMLElement | null>,
   collator?: Intl.Collator,
   layout?: 'stack' | 'grid',
   orientation?: Orientation,
@@ -27,13 +27,13 @@ interface ListKeyboardDelegateOptions<T> {
 export class ListKeyboardDelegate<T> implements KeyboardDelegate {
   private collection: Collection<Node<T>>;
   private disabledKeys: Set<Key>;
-  private ref: RefObject<HTMLElement>;
+  private ref: RefObject<HTMLElement | null>;
   private collator: Intl.Collator | undefined;
   private layout: 'stack' | 'grid';
   private orientation?: Orientation;
   private direction?: Direction;
 
-  constructor(collection: Collection<Node<T>>, disabledKeys: Set<Key>, ref: RefObject<HTMLElement>, collator?: Intl.Collator);
+  constructor(collection: Collection<Node<T>>, disabledKeys: Set<Key>, ref: RefObject<HTMLElement | null>, collator?: Intl.Collator);
   constructor(options: ListKeyboardDelegateOptions<T>);
   constructor(...args: any[]) {
     if (args.length === 1) {

--- a/packages/@react-aria/selection/src/useSelectableCollection.ts
+++ b/packages/@react-aria/selection/src/useSelectableCollection.ts
@@ -33,7 +33,7 @@ export interface AriaSelectableCollectionOptions {
   /**
    * The ref attached to the element representing the collection.
    */
-  ref: RefObject<HTMLElement>,
+  ref: RefObject<HTMLElement | null>,
   /**
    * Whether the collection or one of its items should be automatically focused upon render.
    * @default false
@@ -80,7 +80,7 @@ export interface AriaSelectableCollectionOptions {
    * The ref attached to the scrollable body. Used to provide automatic scrolling on item focus for non-virtualized collections.
    * If not provided, defaults to the collection ref.
    */
-  scrollRef?: RefObject<HTMLElement>,
+  scrollRef?: RefObject<HTMLElement | null>,
   /**
    * The behavior of links in the collection.
    * - 'action': link behaves like onAction.

--- a/packages/@react-aria/selection/src/useSelectableItem.ts
+++ b/packages/@react-aria/selection/src/useSelectableItem.ts
@@ -30,7 +30,7 @@ export interface SelectableItemOptions {
   /**
    * Ref to the item.
    */
-  ref: RefObject<FocusableElement>,
+  ref: RefObject<FocusableElement | null>,
   /**
    * By default, selection occurs on pointer down. This can be strange if selecting an
    * item causes the UI to disappear immediately (e.g. menus).

--- a/packages/@react-aria/slider/src/useSlider.ts
+++ b/packages/@react-aria/slider/src/useSlider.ts
@@ -47,7 +47,7 @@ export interface SliderAria {
 export function useSlider<T extends number | number[]>(
   props: AriaSliderProps<T>,
   state: SliderState,
-  trackRef: RefObject<Element>
+  trackRef: RefObject<Element | null>
 ): SliderAria {
   let {labelProps, fieldProps} = useLabel(props);
 

--- a/packages/@react-aria/slider/src/useSliderThumb.ts
+++ b/packages/@react-aria/slider/src/useSliderThumb.ts
@@ -29,9 +29,9 @@ export interface SliderThumbAria {
 
 export interface AriaSliderThumbOptions extends AriaSliderThumbProps {
   /** A ref to the track element. */
-  trackRef: RefObject<Element>,
+  trackRef: RefObject<Element | null>,
   /** A ref to the thumb input element. */
-  inputRef: RefObject<HTMLInputElement>
+  inputRef: RefObject<HTMLInputElement | null>
 }
 
 /**

--- a/packages/@react-aria/slider/stories/StoryMultiSlider.tsx
+++ b/packages/@react-aria/slider/stories/StoryMultiSlider.tsx
@@ -79,7 +79,7 @@ interface StoryThumbProps extends Omit<SliderThumbProps, 'index'> {
 interface SliderStateContext {
   sliderProps: StoryMultiSliderProps,
   state: SliderState,
-  trackRef: React.RefObject<Element>,
+  trackRef: React.RefObject<Element | null>,
   index: number
 }
 

--- a/packages/@react-aria/spinbutton/src/useSpinButton.ts
+++ b/packages/@react-aria/spinbutton/src/useSpinButton.ts
@@ -39,7 +39,7 @@ export interface SpinbuttonAria {
 export function useSpinButton(
   props: SpinButtonProps
 ): SpinbuttonAria {
-  const _async = useRef<number>();
+  const _async = useRef<number>(undefined);
   let {
     value,
     textValue,

--- a/packages/@react-aria/steplist/src/useStepList.ts
+++ b/packages/@react-aria/steplist/src/useStepList.ts
@@ -25,7 +25,7 @@ export interface StepListAria {
   listProps: HTMLAttributes<HTMLElement>
 }
 
-export function useStepList<T>(props: AriaStepListProps<T>, state: StepListState<T>, ref: RefObject<HTMLOListElement>): StepListAria {
+export function useStepList<T>(props: AriaStepListProps<T>, state: StepListState<T>, ref: RefObject<HTMLOListElement | null>): StepListAria {
   let {
     'aria-label': ariaLabel
   } = props;

--- a/packages/@react-aria/steplist/src/useStepListItem.ts
+++ b/packages/@react-aria/steplist/src/useStepListItem.ts
@@ -28,7 +28,7 @@ export interface StepListItemAria {
   stepStateText?: String
 }
 
-export function useStepListItem<T>(props: AriaStepListItemProps, state: StepListState<T>, ref: RefObject<HTMLElement>): StepListItemAria {
+export function useStepListItem<T>(props: AriaStepListItemProps, state: StepListState<T>, ref: RefObject<HTMLElement | null>): StepListItemAria {
   const {key} = props;
   let {selectionManager: manager, selectedKey} = state;
 

--- a/packages/@react-aria/switch/src/useSwitch.ts
+++ b/packages/@react-aria/switch/src/useSwitch.ts
@@ -37,7 +37,7 @@ export interface SwitchAria {
  * @param state - State for the switch, as returned by `useToggleState`.
  * @param ref - Ref to the HTML input element.
  */
-export function useSwitch(props: AriaSwitchProps, state: ToggleState, ref: RefObject<HTMLInputElement>): SwitchAria {
+export function useSwitch(props: AriaSwitchProps, state: ToggleState, ref: RefObject<HTMLInputElement | null>): SwitchAria {
   let {labelProps, inputProps, isSelected, isPressed, isDisabled, isReadOnly} = useToggle(props, state, ref);
 
   return {

--- a/packages/@react-aria/table/src/useTable.ts
+++ b/packages/@react-aria/table/src/useTable.ts
@@ -37,7 +37,7 @@ export interface AriaTableProps<T> extends GridProps {
  * @param state - State for the table, as returned by `useTableState`.
  * @param ref - The ref attached to the table element.
  */
-export function useTable<T>(props: AriaTableProps<T>, state: TableState<T> | TreeGridState<T>, ref: RefObject<HTMLElement>): GridAria {
+export function useTable<T>(props: AriaTableProps<T>, state: TableState<T> | TreeGridState<T>, ref: RefObject<HTMLElement | null>): GridAria {
   let {
     keyboardDelegate,
     isVirtualized,

--- a/packages/@react-aria/table/src/useTableCell.ts
+++ b/packages/@react-aria/table/src/useTableCell.ts
@@ -45,7 +45,7 @@ export interface TableCellAria {
  * @param state - State of the table, as returned by `useTableState`.
  * @param ref - The ref attached to the cell element.
  */
-export function useTableCell<T>(props: AriaTableCellProps, state: TableState<T>, ref: RefObject<FocusableElement>): TableCellAria {
+export function useTableCell<T>(props: AriaTableCellProps, state: TableState<T>, ref: RefObject<FocusableElement | null>): TableCellAria {
   let {gridCellProps, isPressed} = useGridCell(props, state, ref);
 
   let columnKey = props.node.column.key;

--- a/packages/@react-aria/table/src/useTableColumnHeader.ts
+++ b/packages/@react-aria/table/src/useTableColumnHeader.ts
@@ -41,7 +41,7 @@ export interface TableColumnHeaderAria {
  * @param state - State of the table, as returned by `useTableState`.
  * @param ref - The ref attached to the column header element.
  */
-export function useTableColumnHeader<T>(props: AriaTableColumnHeaderProps<T>, state: TableState<T>, ref: RefObject<FocusableElement>): TableColumnHeaderAria {
+export function useTableColumnHeader<T>(props: AriaTableColumnHeaderProps<T>, state: TableState<T>, ref: RefObject<FocusableElement | null>): TableColumnHeaderAria {
   let {node} = props;
   let allowsSorting = node.props.allowsSorting;
   // if there are no focusable children, the column header will focus the cell

--- a/packages/@react-aria/table/src/useTableColumnResize.ts
+++ b/packages/@react-aria/table/src/useTableColumnResize.ts
@@ -43,7 +43,7 @@ export interface AriaTableColumnResizeProps<T> {
    * focus will be returned there when resizing is done. If it isn't provided, it is assumed that the resizer is
    * visible at all time and keyboard resizing is started via pressing Enter on the resizer and not on focus.
    * */
-  triggerRef?: RefObject<FocusableElement>,
+  triggerRef?: RefObject<FocusableElement | null>,
   /** If resizing is disabled. */
   isDisabled?: boolean,
   /** Called when resizing starts. */
@@ -60,7 +60,7 @@ export interface AriaTableColumnResizeProps<T> {
  * @param state - State for the table's resizable columns, as returned by `useTableColumnResizeState`.
  * @param ref - The ref attached to the resizer's visually hidden input element.
  */
-export function useTableColumnResize<T>(props: AriaTableColumnResizeProps<T>, state: TableColumnResizeState<T>, ref: RefObject<HTMLInputElement>): TableColumnResizeAria {
+export function useTableColumnResize<T>(props: AriaTableColumnResizeProps<T>, state: TableColumnResizeState<T>, ref: RefObject<HTMLInputElement | null>): TableColumnResizeAria {
   let {column: item, triggerRef, isDisabled, onResizeStart, onResize, onResizeEnd, 'aria-label': ariaLabel} = props;
   const stringFormatter = useLocalizedStringFormatter(intlMessages, '@react-aria/table');
   let id = useId();

--- a/packages/@react-aria/table/src/useTableHeaderRow.ts
+++ b/packages/@react-aria/table/src/useTableHeaderRow.ts
@@ -27,7 +27,7 @@ export interface TableHeaderRowAria {
  * @param state - State of the table, as returned by `useTableState`.
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function useTableHeaderRow<T>(props: GridRowProps<T>, state: TableState<T>, ref: RefObject<Element>): TableHeaderRowAria {
+export function useTableHeaderRow<T>(props: GridRowProps<T>, state: TableState<T>, ref: RefObject<Element | null>): TableHeaderRowAria {
   let {node, isVirtualized} = props;
   let rowProps = {
     role: 'row'

--- a/packages/@react-aria/table/src/useTableRow.ts
+++ b/packages/@react-aria/table/src/useTableRow.ts
@@ -38,7 +38,7 @@ const EXPANSION_KEYS = {
  * @param props - Props for the row.
  * @param state - State of the table, as returned by `useTableState`.
  */
-export function useTableRow<T>(props: GridRowProps<T>, state: TableState<T> | TreeGridState<T>, ref: RefObject<FocusableElement>): GridRowAria {
+export function useTableRow<T>(props: GridRowProps<T>, state: TableState<T> | TreeGridState<T>, ref: RefObject<FocusableElement | null>): GridRowAria {
   let {node, isVirtualized} = props;
   let {rowProps, ...states} = useGridRow<T, TableCollection<T>, TableState<T>>(props, state, ref);
   let {direction} = useLocale();

--- a/packages/@react-aria/table/stories/example-backwards-compat.tsx
+++ b/packages/@react-aria/table/stories/example-backwards-compat.tsx
@@ -40,8 +40,8 @@ export function Table(props) {
   if (shouldShowCheckboxes !== showSelectionCheckboxes) {
     setShowSelectionCheckboxes(shouldShowCheckboxes);
   }
-  let ref = useRef();
-  let bodyRef = useRef();
+  let ref = useRef(undefined);
+  let bodyRef = useRef(undefined);
   let {collection} = state;
   let {gridProps} = useTable({...props, scrollRef: bodyRef}, state, ref);
 
@@ -84,7 +84,7 @@ export const TableRowGroup = React.forwardRef((props: any, ref) => {
 });
 
 export function TableHeaderRow({item, state, children}) {
-  let ref = useRef();
+  let ref = useRef(undefined);
   let {rowProps} = useTableHeaderRow({node: item}, state, ref);
 
   return (
@@ -95,7 +95,7 @@ export function TableHeaderRow({item, state, children}) {
 }
 
 export function TableColumnHeader({column, state}) {
-  let ref = useRef();
+  let ref = useRef(undefined);
   let {columnHeaderProps} = useTableColumnHeader({node: column}, state, ref);
   let {isFocusVisible, focusProps} = useFocusRing();
   let arrowIcon = state.sortDescriptor?.direction === 'ascending' ? '▲' : '▼';
@@ -122,7 +122,7 @@ export function TableColumnHeader({column, state}) {
 }
 
 export function TableRow({item, children, state, onAction}: {item: any, children: ReactNode, state: any, onAction?: (key: string) => void}) {
-  let ref = useRef();
+  let ref = useRef(undefined);
   let isSelected = state.selectionManager.isSelected(item.key);
   let {rowProps} = useTableRow({node: item, onAction: onAction ? () => onAction(item.key) : undefined}, state, ref);
   let {isFocusVisible, focusProps} = useFocusRing();
@@ -147,7 +147,7 @@ export function TableRow({item, children, state, onAction}: {item: any, children
 }
 
 export function TableCell({cell, state}) {
-  let ref = useRef();
+  let ref = useRef(undefined);
   let {gridCellProps} = useTableCell({node: cell}, state, ref);
   let {isFocusVisible, focusProps} = useFocusRing();
 
@@ -166,7 +166,7 @@ export function TableCell({cell, state}) {
 }
 
 export function TableCheckboxCell({cell, state}) {
-  let ref = useRef();
+  let ref = useRef(undefined);
   let {gridCellProps} = useTableCell({node: cell}, state, ref);
   let {checkboxProps} = useTableSelectionCheckbox({key: cell.parentKey}, state);
 
@@ -183,7 +183,7 @@ export function TableCheckboxCell({cell, state}) {
 }
 
 export function TableSelectAllCell({column, state}) {
-  let ref = useRef();
+  let ref = useRef(undefined);
   let isSingleSelectionMode = state.selectionManager.selectionMode === 'single';
   let {columnHeaderProps} = useTableColumnHeader({node: column}, state, ref);
 

--- a/packages/@react-aria/table/stories/example-docs.tsx
+++ b/packages/@react-aria/table/stories/example-docs.tsx
@@ -27,7 +27,7 @@ export function Table(props) {
   } = props;
 
   let state = useTableState(props);
-  let ref = useRef();
+  let ref = useRef(undefined);
   let {collection} = state;
   let {gridProps} = useTable(
     {
@@ -103,7 +103,7 @@ function ResizableTableRowGroup({type: Element, children, className}) {
 }
 
 function ResizableTableHeaderRow({item, state, children}) {
-  let ref = useRef();
+  let ref = useRef(undefined);
   let {rowProps} = useTableHeaderRow({node: item}, state, ref);
 
   return (
@@ -151,7 +151,7 @@ function Button(props) {
 
 function Resizer(props) {
   let {column, layoutState, onResizeStart, onResize, onResizeEnd} = props;
-  let ref = useRef();
+  let ref = useRef(undefined);
   let {resizerProps, inputProps, isResizing} = useTableColumnResize({
     column,
     'aria-label': 'Resizer',
@@ -174,7 +174,7 @@ function Resizer(props) {
 }
 
 function ResizableTableRow({item, children, state}) {
-  let ref = useRef();
+  let ref = useRef(undefined);
   let isSelected = state.selectionManager.isSelected(item.key);
   let {rowProps, isPressed} = useTableRow({
     node: item
@@ -206,7 +206,7 @@ function ResizableTableRow({item, children, state}) {
 }
 
 function ResizableTableCell({cell, state, layoutState}) {
-  let ref = useRef();
+  let ref = useRef(undefined);
   let {gridCellProps} = useTableCell({node: cell}, state, ref);
   let {isFocusVisible, focusProps} = useFocusRing();
   let column = cell.column;

--- a/packages/@react-aria/table/stories/example-resizing.tsx
+++ b/packages/@react-aria/table/stories/example-resizing.tsx
@@ -116,7 +116,7 @@ export const TableRowGroup = React.forwardRef((props: any, ref) => {
 });
 
 export function TableHeaderRow({item, state, children, className}) {
-  let ref = useRef();
+  let ref = useRef(undefined);
   let {rowProps} = useTableHeaderRow({node: item}, state, ref);
 
   return (
@@ -163,7 +163,7 @@ function Resizer({column, layout, onResizeStart, onResize, onResizeEnd}) {
   );
 }
 export function TableColumnHeader({column, state, layout, onResizeStart, onResize, onResizeEnd}) {
-  let ref = useRef();
+  let ref = useRef(undefined);
   let {columnHeaderProps} = useTableColumnHeader({node: column}, state, ref);
   let {isFocusVisible, focusProps} = useFocusRing();
   let arrowIcon = state.sortDescriptor?.direction === 'ascending' ? '▲' : '▼';
@@ -204,7 +204,7 @@ export function TableColumnHeader({column, state, layout, onResizeStart, onResiz
 }
 
 export function TableRow({item, children, state, className}) {
-  let ref = useRef();
+  let ref = useRef(undefined);
   let isSelected = state.selectionManager.isSelected(item.key);
   let {rowProps} = useTableRow({node: item}, state, ref);
   let {isFocusVisible, focusProps} = useFocusRing();
@@ -224,7 +224,7 @@ export function TableRow({item, children, state, className}) {
 }
 
 export function TableCell({cell, state, layout}) {
-  let ref = useRef();
+  let ref = useRef(undefined);
   let {gridCellProps} = useTableCell({node: cell}, state, ref);
   let {isFocusVisible, focusProps} = useFocusRing();
   let column = cell.column;
@@ -257,7 +257,7 @@ export function TableCell({cell, state, layout}) {
 }
 
 export function TableCheckboxCell({cell, state, layout}) {
-  let ref = useRef();
+  let ref = useRef(undefined);
   let {gridCellProps} = useTableCell({node: cell}, state, ref);
   let {checkboxProps} = useTableSelectionCheckbox({key: cell.parentKey}, state);
 
@@ -278,7 +278,7 @@ export function TableCheckboxCell({cell, state, layout}) {
 }
 
 export function TableSelectAllCell({column, state, layout}) {
-  let ref = useRef();
+  let ref = useRef(undefined);
   let isSingleSelectionMode = state.selectionManager.selectionMode === 'single';
   let {columnHeaderProps} = useTableColumnHeader({node: column}, state, ref);
 

--- a/packages/@react-aria/table/stories/example.tsx
+++ b/packages/@react-aria/table/stories/example.tsx
@@ -31,8 +31,8 @@ export function Table(props) {
   if (shouldShowCheckboxes !== showSelectionCheckboxes) {
     setShowSelectionCheckboxes(shouldShowCheckboxes);
   }
-  let ref = useRef();
-  let bodyRef = useRef();
+  let ref = useRef(undefined);
+  let bodyRef = useRef(undefined);
   let {collection} = state;
   let {gridProps} = useTable(
     {
@@ -83,7 +83,7 @@ export const TableRowGroup = React.forwardRef((props: any, ref) => {
 });
 
 export function TableHeaderRow({item, state, children}) {
-  let ref = useRef();
+  let ref = useRef(undefined);
   let {rowProps} = useTableHeaderRow({node: item}, state, ref);
 
   return (
@@ -94,7 +94,7 @@ export function TableHeaderRow({item, state, children}) {
 }
 
 export function TableColumnHeader({column, state}) {
-  let ref = useRef();
+  let ref = useRef(undefined);
   let {columnHeaderProps} = useTableColumnHeader({node: column}, state, ref);
   let {isFocusVisible, focusProps} = useFocusRing();
   let arrowIcon = state.sortDescriptor?.direction === 'ascending' ? '▲' : '▼';
@@ -121,7 +121,7 @@ export function TableColumnHeader({column, state}) {
 }
 
 export function TableRow({item, children, state}) {
-  let ref = useRef();
+  let ref = useRef(undefined);
   let isSelected = state.selectionManager.isSelected(item.key);
   let {rowProps} = useTableRow({node: item}, state, ref);
   let {isFocusVisible, focusProps} = useFocusRing();
@@ -146,7 +146,7 @@ export function TableRow({item, children, state}) {
 }
 
 export function TableCell({cell, state}) {
-  let ref = useRef();
+  let ref = useRef(undefined);
   let {gridCellProps} = useTableCell({node: cell}, state, ref);
   let {isFocusVisible, focusProps} = useFocusRing();
 
@@ -165,7 +165,7 @@ export function TableCell({cell, state}) {
 }
 
 export function TableCheckboxCell({cell, state}) {
-  let ref = useRef();
+  let ref = useRef(undefined);
   let {gridCellProps} = useTableCell({node: cell}, state, ref);
   let {checkboxProps} = useTableSelectionCheckbox({key: cell.parentKey}, state);
 
@@ -182,7 +182,7 @@ export function TableCheckboxCell({cell, state}) {
 }
 
 export function TableSelectAllCell({column, state}) {
-  let ref = useRef();
+  let ref = useRef(undefined);
   let isSingleSelectionMode = state.selectionManager.selectionMode === 'single';
   let {columnHeaderProps} = useTableColumnHeader({node: column}, state, ref);
 

--- a/packages/@react-aria/table/test/useTable.test.tsx
+++ b/packages/@react-aria/table/test/useTable.test.tsx
@@ -48,8 +48,8 @@ function Table(props) {
     ...props,
     showSelectionCheckboxes: props.selectionMode === 'multiple'
   });
-  let ref = useRef();
-  let bodyRef = useRef();
+  let ref = useRef(undefined);
+  let bodyRef = useRef(undefined);
   let {collection} = state;
   let {gridProps} = useTable(
     {

--- a/packages/@react-aria/table/test/useTableBackwardCompat.test.tsx
+++ b/packages/@react-aria/table/test/useTableBackwardCompat.test.tsx
@@ -49,8 +49,8 @@ function Table(props) {
     ...otherProps,
     showSelectionCheckboxes: otherProps.selectionMode === 'multiple'
   });
-  let ref = useRef();
-  let bodyRef = useRef();
+  let ref = useRef(undefined);
+  let bodyRef = useRef(undefined);
   let {collection} = state;
   let {gridProps} = useTable({...otherProps, scrollRef: bodyRef}, state, ref);
 

--- a/packages/@react-aria/tabs/src/useTab.ts
+++ b/packages/@react-aria/tabs/src/useTab.ts
@@ -36,7 +36,7 @@ export interface TabAria {
 export function useTab<T>(
   props: AriaTabProps,
   state: TabListState<T>,
-  ref: RefObject<FocusableElement>
+  ref: RefObject<FocusableElement | null>
 ): TabAria {
   let {key, isDisabled: propsDisabled, shouldSelectOnPressUp} = props;
   let {selectionManager: manager, selectedKey} = state;

--- a/packages/@react-aria/tabs/src/useTabList.ts
+++ b/packages/@react-aria/tabs/src/useTabList.ts
@@ -31,7 +31,7 @@ export interface TabListAria {
  * Provides the behavior and accessibility implementation for a tab list.
  * Tabs organize content into multiple sections and allow users to navigate between them.
  */
-export function useTabList<T>(props: AriaTabListOptions<T>, state: TabListState<T>, ref: RefObject<HTMLElement>): TabListAria {
+export function useTabList<T>(props: AriaTabListOptions<T>, state: TabListState<T>, ref: RefObject<HTMLElement | null>): TabListAria {
   let {
     orientation = 'horizontal',
     keyboardActivation = 'automatic'

--- a/packages/@react-aria/tabs/src/useTabPanel.ts
+++ b/packages/@react-aria/tabs/src/useTabPanel.ts
@@ -28,7 +28,7 @@ export interface TabPanelAria {
  * Provides the behavior and accessibility implementation for a tab panel. A tab panel is a container for
  * the contents of a tab, and is shown when the tab is selected.
  */
-export function useTabPanel<T>(props: AriaTabPanelProps, state: TabListState<T>, ref: RefObject<Element>): TabPanelAria {
+export function useTabPanel<T>(props: AriaTabPanelProps, state: TabListState<T>, ref: RefObject<Element | null>): TabPanelAria {
   // The tabpanel should have tabIndex=0 when there are no tabbable elements within it.
   // Otherwise, tabbing from the focused tab should go directly to the first tabbable element
   // within the tabpanel.

--- a/packages/@react-aria/tag/src/useTag.ts
+++ b/packages/@react-aria/tag/src/useTag.ts
@@ -46,7 +46,7 @@ export interface AriaTagProps<T> {
  * @param state - State for the tag group, as returned by `useListState`.
  * @param ref - A ref to a DOM element for the tag.
  */
-export function useTag<T>(props: AriaTagProps<T>, state: ListState<T>, ref: RefObject<FocusableElement>): TagAria {
+export function useTag<T>(props: AriaTagProps<T>, state: ListState<T>, ref: RefObject<FocusableElement | null>): TagAria {
   let {item} = props;
   let stringFormatter = useLocalizedStringFormatter(intlMessages, '@react-aria/tag');
   let buttonId = useId();

--- a/packages/@react-aria/tag/src/useTagGroup.ts
+++ b/packages/@react-aria/tag/src/useTagGroup.ts
@@ -61,7 +61,7 @@ export const hookData = new WeakMap<ListState<any>, HookData>();
  * @param state - State for the tag group, as returned by `useListState`.
  * @param ref - A ref to a DOM element for the tag group.
  */
-export function useTagGroup<T>(props: AriaTagGroupOptions<T>, state: ListState<T>, ref: RefObject<HTMLElement>): TagGroupAria {
+export function useTagGroup<T>(props: AriaTagGroupOptions<T>, state: ListState<T>, ref: RefObject<HTMLElement | null>): TagGroupAria {
   let {direction} = useLocale();
   let keyboardDelegate = props.keyboardDelegate || new ListKeyboardDelegate({
     collection: state.collection,

--- a/packages/@react-aria/textfield/src/useFormattedTextField.ts
+++ b/packages/@react-aria/textfield/src/useFormattedTextField.ts
@@ -28,7 +28,7 @@ function supportsNativeBeforeInputEvent() {
     typeof InputEvent.prototype.getTargetRanges === 'function';
 }
 
-export function useFormattedTextField(props: AriaTextFieldProps, state: FormattedTextFieldState, inputRef: RefObject<HTMLInputElement>): TextFieldAria {
+export function useFormattedTextField(props: AriaTextFieldProps, state: FormattedTextFieldState, inputRef: RefObject<HTMLInputElement | null>): TextFieldAria {
   // All browsers implement the 'beforeinput' event natively except Firefox
   // (currently behind a flag as of Firefox 84). React's polyfill does not
   // run in all cases that the native event fires, e.g. when deleting text.

--- a/packages/@react-aria/textfield/src/useTextField.ts
+++ b/packages/@react-aria/textfield/src/useTextField.ts
@@ -92,7 +92,7 @@ export interface AriaTextFieldOptions<T extends TextFieldIntrinsicElements> exte
  * intrinsic HTML element name; e.g.`RefObject<HTMLInputElement>`,
  * `RefObject<HTMLTextAreaElement>`.
  */
-type TextFieldRefObject<T extends TextFieldIntrinsicElements> = RefObject<TextFieldHTMLElementType[T]>;
+type TextFieldRefObject<T extends TextFieldIntrinsicElements> = RefObject<TextFieldHTMLElementType[T] | null>;
 
 export interface TextFieldAria<T extends TextFieldIntrinsicElements = DefaultElementType> extends ValidationResult {
   /** Props for the input element. */

--- a/packages/@react-aria/textfield/src/useTextField.ts
+++ b/packages/@react-aria/textfield/src/useTextField.ts
@@ -13,10 +13,9 @@
 import {AriaTextFieldProps} from '@react-types/textfield';
 import {
   ChangeEvent,
-  DOMFactory,
   HTMLAttributes,
+  type JSX,
   LabelHTMLAttributes,
-  ReactDOM,
   RefObject,
   useEffect
 } from 'react';
@@ -40,9 +39,7 @@ type IntrinsicHTMLElements = {
  * A map of HTML element names and their attribute interface types.
  * For example `'a'` -> `AnchorHTMLAttributes<HTMLAnchorElement>`.
  */
-type IntrinsicHTMLAttributes = {
-  [K in keyof ReactDOM]: ReactDOM[K] extends DOMFactory<infer T, any> ? T : never
-};
+type IntrinsicHTMLAttributes =  JSX.IntrinsicElements
 
 type DefaultElementType = 'input';
 
@@ -81,7 +78,7 @@ export interface AriaTextFieldOptions<T extends TextFieldIntrinsicElements> exte
    */
   inputElementType?: T,
   /**
-   * Controls whether inputted text is automatically capitalized and, if so, in what manner. 
+   * Controls whether inputted text is automatically capitalized and, if so, in what manner.
    * See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autocapitalize).
    */
   autoCapitalize?: 'off' | 'none' | 'on' | 'sentences' | 'words' | 'characters'

--- a/packages/@react-aria/textfield/stories/useTextField.stories.tsx
+++ b/packages/@react-aria/textfield/stories/useTextField.stories.tsx
@@ -9,7 +9,7 @@ interface TextFieldProps {
 
 const TextInputField = (props: TextFieldProps) => {
   const {label} = props;
-  const ref = useRef<HTMLInputElement>();
+  const ref = useRef<HTMLInputElement>(undefined);
   const {labelProps, inputProps} = useTextField(props, ref);
 
   return (
@@ -22,7 +22,7 @@ const TextInputField = (props: TextFieldProps) => {
 
 const TextAreaField = (props: TextFieldProps) => {
   const {label} = props;
-  const ref = useRef<HTMLTextAreaElement>();
+  const ref = useRef<HTMLTextAreaElement>(undefined);
   const {labelProps, inputProps} = useTextField({...props, inputElementType: 'textarea'}, ref);
 
   return (

--- a/packages/@react-aria/toast/src/useToast.ts
+++ b/packages/@react-aria/toast/src/useToast.ts
@@ -39,7 +39,7 @@ export interface ToastAria {
  * Provides the behavior and accessibility implementation for a toast component.
  * Toasts display brief, temporary notifications of actions, errors, or other events in an application.
  */
-export function useToast<T>(props: AriaToastProps<T>, state: ToastState<T>, ref: RefObject<FocusableElement>): ToastAria {
+export function useToast<T>(props: AriaToastProps<T>, state: ToastState<T>, ref: RefObject<FocusableElement | null>): ToastAria {
   let {
     key,
     timer,

--- a/packages/@react-aria/toast/src/useToastRegion.ts
+++ b/packages/@react-aria/toast/src/useToastRegion.ts
@@ -25,7 +25,7 @@ export interface ToastRegionAria {
  * Provides the behavior and accessibility implementation for a toast region containing one or more toasts.
  * Toasts display brief, temporary notifications of actions, errors, or other events in an application.
  */
-export function useToastRegion<T>(props: AriaToastRegionProps, state: ToastState<T>, ref: RefObject<HTMLElement>): ToastRegionAria {
+export function useToastRegion<T>(props: AriaToastRegionProps, state: ToastState<T>, ref: RefObject<HTMLElement | null>): ToastRegionAria {
   let stringFormatter = useLocalizedStringFormatter(intlMessages, '@react-aria/toast');
   let {landmarkProps} = useLandmark({
     role: 'region',

--- a/packages/@react-aria/toast/stories/Example.tsx
+++ b/packages/@react-aria/toast/stories/Example.tsx
@@ -29,7 +29,7 @@ export function ToastContainer({children, ...otherProps}) {
 
 function ToastRegion() {
   let state = useContext(ToastContext);
-  let ref = useRef();
+  let ref = useRef(undefined);
   let {regionProps} = useToastRegion({}, state, ref);
   return (
     <div {...regionProps} ref={ref} style={{position: 'fixed', bottom: 0, right: 0}}>
@@ -44,7 +44,7 @@ function Toast(props) {
   let state = useContext(ToastContext);
   let ref = useRef(null);
   let {toastProps, titleProps, closeButtonProps} = useToast(props, state, ref);
-  let buttonRef = useRef();
+  let buttonRef = useRef(undefined);
   let {buttonProps} = useButton(closeButtonProps, buttonRef);
 
   return (

--- a/packages/@react-aria/toggle/src/useToggle.ts
+++ b/packages/@react-aria/toggle/src/useToggle.ts
@@ -37,7 +37,7 @@ export interface ToggleAria {
 /**
  * Handles interactions for toggle elements, e.g. Checkboxes and Switches.
  */
-export function useToggle(props: AriaToggleProps, state: ToggleState, ref: RefObject<HTMLInputElement>): ToggleAria {
+export function useToggle(props: AriaToggleProps, state: ToggleState, ref: RefObject<HTMLInputElement | null>): ToggleAria {
   let {
     isDisabled = false,
     isReadOnly = false,

--- a/packages/@react-aria/toolbar/src/useToolbar.ts
+++ b/packages/@react-aria/toolbar/src/useToolbar.ts
@@ -37,7 +37,7 @@ export interface ToolbarAria {
  * @param props - Props to be applied to the toolbar.
  * @param ref - A ref to a DOM element for the toolbar.
  */
-export function useToolbar(props: AriaToolbarProps, ref: RefObject<HTMLDivElement>): ToolbarAria {
+export function useToolbar(props: AriaToolbarProps, ref: RefObject<HTMLDivElement | null>): ToolbarAria {
   const {
     'aria-label': ariaLabel,
     'aria-labelledby': ariaLabelledBy,

--- a/packages/@react-aria/tooltip/src/useTooltipTrigger.ts
+++ b/packages/@react-aria/tooltip/src/useTooltipTrigger.ts
@@ -34,7 +34,7 @@ export interface TooltipTriggerAria {
  * Provides the behavior and accessibility implementation for a tooltip trigger, e.g. a button
  * that shows a description when focused or hovered.
  */
-export function useTooltipTrigger(props: TooltipTriggerProps, state: TooltipTriggerState, ref: RefObject<FocusableElement>) : TooltipTriggerAria {
+export function useTooltipTrigger(props: TooltipTriggerProps, state: TooltipTriggerState, ref: RefObject<FocusableElement | null>) : TooltipTriggerAria {
   let {
     isDisabled,
     trigger

--- a/packages/@react-aria/tree/src/useTreeGridList.ts
+++ b/packages/@react-aria/tree/src/useTreeGridList.ts
@@ -41,7 +41,7 @@ export interface TreeGridListAria {
  * @param state - State for the treegrid, as returned by `useTreeState`.
  * @param ref - The ref attached to the treegrid element.
  */
-export function useTreeGridList<T>(props: AriaTreeGridListOptions<T>, state: TreeState<T>, ref: RefObject<HTMLElement>): TreeGridListAria {
+export function useTreeGridList<T>(props: AriaTreeGridListOptions<T>, state: TreeState<T>, ref: RefObject<HTMLElement | null>): TreeGridListAria {
   let {gridProps} = useGridList(props, state, ref);
   gridProps.role = 'treegrid';
 

--- a/packages/@react-aria/tree/src/useTreeGridListItem.ts
+++ b/packages/@react-aria/tree/src/useTreeGridListItem.ts
@@ -35,7 +35,7 @@ export interface TreeGridListItemAria extends GridListItemAria {
  * @param state - State of the parent list, as returned by `useTreeState`.
  * @param ref - The ref attached to the row element.
  */
-export function useTreeGridListItem<T>(props: AriaTreeGridListItemOptions, state: TreeState<T>, ref: RefObject<FocusableElement>): TreeGridListItemAria {
+export function useTreeGridListItem<T>(props: AriaTreeGridListItemOptions, state: TreeState<T>, ref: RefObject<FocusableElement | null>): TreeGridListItemAria {
    // TODO: should it return a state specifically for isExpanded? Or is aria attribute sufficient?
   return useGridListItem(props, state, ref);
 }

--- a/packages/@react-aria/utils/src/useEvent.ts
+++ b/packages/@react-aria/utils/src/useEvent.ts
@@ -14,7 +14,7 @@ import {RefObject, useEffect} from 'react';
 import {useEffectEvent} from './useEffectEvent';
 
 export function useEvent<K extends keyof GlobalEventHandlersEventMap>(
-  ref: RefObject<EventTarget>,
+  ref: RefObject<EventTarget | null>,
   event: K,
   handler?: (this: Document, ev: GlobalEventHandlersEventMap[K]) => any,
   options?: boolean | AddEventListenerOptions

--- a/packages/@react-aria/utils/src/useFormReset.ts
+++ b/packages/@react-aria/utils/src/useFormReset.ts
@@ -13,7 +13,7 @@ import {RefObject, useEffect, useRef} from 'react';
 import {useEffectEvent} from './useEffectEvent';
 
 export function useFormReset<T>(
-  ref: RefObject<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
+  ref: RefObject<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement | null>,
   initialValue: T,
   onReset: (value: T) => void
 ) {

--- a/packages/@react-aria/utils/src/useResizeObserver.ts
+++ b/packages/@react-aria/utils/src/useResizeObserver.ts
@@ -5,7 +5,7 @@ function hasResizeObserver() {
 }
 
 type useResizeObserverOptionsType<T> = {
-  ref: RefObject<T | undefined> | undefined,
+  ref: RefObject<T | undefined | null> | undefined,
   onResize: () => void
 }
 

--- a/packages/@react-aria/utils/src/useSyncRef.ts
+++ b/packages/@react-aria/utils/src/useSyncRef.ts
@@ -18,7 +18,7 @@ interface ContextValue<T> {
 }
 
 // Syncs ref from context with ref passed to hook
-export function useSyncRef<T>(context?: ContextValue<T> | null, ref?: RefObject<T>) {
+export function useSyncRef<T>(context?: ContextValue<T> | null, ref?: RefObject<T | null>) {
   useLayoutEffect(() => {
     if (context && context.ref && ref) {
       context.ref.current = ref.current;

--- a/packages/@react-aria/virtualizer/src/ScrollView.tsx
+++ b/packages/@react-aria/virtualizer/src/ScrollView.tsx
@@ -40,7 +40,7 @@ interface ScrollViewProps extends HTMLAttributes<HTMLElement> {
 
 let isOldReact = React.version.startsWith('16.') || React.version.startsWith('17.');
 
-function ScrollView(props: ScrollViewProps, ref: RefObject<HTMLDivElement>) {
+function ScrollView(props: ScrollViewProps, ref: RefObject<HTMLDivElement | null>) {
   let {
     contentSize,
     onVisibleRectChange,
@@ -53,7 +53,7 @@ function ScrollView(props: ScrollViewProps, ref: RefObject<HTMLDivElement>) {
     ...otherProps
   } = props;
 
-  let defaultRef = useRef();
+  let defaultRef = useRef(undefined);
   ref = ref || defaultRef;
   let state = useRef({
     scrollTop: 0,
@@ -154,7 +154,7 @@ function ScrollView(props: ScrollViewProps, ref: RefObject<HTMLDivElement>) {
   useLayoutEffect(() => {
     updateSize();
   }, [updateSize]);
-  let raf = useRef<ReturnType<typeof requestAnimationFrame> | null>();
+  let raf = useRef<ReturnType<typeof requestAnimationFrame> | null>(undefined);
   let onResize = () => {
     if (isOldReact) {
       raf.current ??= requestAnimationFrame(() => {

--- a/packages/@react-aria/virtualizer/src/Virtualizer.tsx
+++ b/packages/@react-aria/virtualizer/src/Virtualizer.tsx
@@ -39,7 +39,7 @@ interface VirtualizerProps<T extends object, V> extends Omit<HTMLAttributes<HTML
   autoFocus?: boolean
 }
 
-function Virtualizer<T extends object, V extends ReactNode>(props: VirtualizerProps<T, V>, ref: RefObject<HTMLDivElement>) {
+function Virtualizer<T extends object, V extends ReactNode>(props: VirtualizerProps<T, V>, ref: RefObject<HTMLDivElement | null>) {
   let {
     children: renderView,
     renderWrapper,
@@ -63,7 +63,7 @@ function Virtualizer<T extends object, V extends ReactNode>(props: VirtualizerPr
     ...otherProps
   } = props;
 
-  let fallbackRef = useRef<HTMLDivElement>();
+  let fallbackRef = useRef<HTMLDivElement>(undefined);
   ref = ref || fallbackRef;
 
   let state = useVirtualizerState({
@@ -105,7 +105,7 @@ interface VirtualizerOptions {
   onLoadMore?: () => void
 }
 
-export function useVirtualizer<T extends object, V extends ReactNode, W>(props: VirtualizerOptions, state: VirtualizerState<T, V, W>, ref: RefObject<HTMLElement>) {
+export function useVirtualizer<T extends object, V extends ReactNode, W>(props: VirtualizerOptions, state: VirtualizerState<T, V, W>, ref: RefObject<HTMLElement | null>) {
   let {focusedKey, scrollToItem, shouldUseVirtualFocus, isLoading, onLoadMore} = props;
   let {virtualizer} = state;
   // Scroll to the focusedKey when it changes. Actually focusing the focusedKey
@@ -237,7 +237,7 @@ export function useVirtualizer<T extends object, V extends ReactNode, W>(props: 
 
 // forwardRef doesn't support generic parameters, so cast the result to the correct type
 // https://stackoverflow.com/questions/58469229/react-with-typescript-generics-while-using-react-forwardref
-const _Virtualizer = React.forwardRef(Virtualizer) as <T extends object, V>(props: VirtualizerProps<T, V> & {ref?: RefObject<HTMLDivElement>}) => ReactElement;
+const _Virtualizer = React.forwardRef(Virtualizer) as <T extends object, V>(props: VirtualizerProps<T, V> & {ref?: RefObject<HTMLDivElement | null>}) => ReactElement;
 export {_Virtualizer as Virtualizer};
 
 function defaultRenderWrapper<T extends object, V extends ReactNode>(

--- a/packages/@react-aria/virtualizer/src/VirtualizerItem.tsx
+++ b/packages/@react-aria/virtualizer/src/VirtualizerItem.tsx
@@ -25,7 +25,7 @@ interface VirtualizerItemProps extends Omit<VirtualizerItemOptions, 'ref'> {
 export function VirtualizerItem(props: VirtualizerItemProps) {
   let {className, layoutInfo, virtualizer, parent, children} = props;
   let {direction} = useLocale();
-  let ref = useRef();
+  let ref = useRef(undefined);
   useVirtualizerItem({
     layoutInfo,
     virtualizer,

--- a/packages/@react-aria/virtualizer/src/useVirtualizerItem.ts
+++ b/packages/@react-aria/virtualizer/src/useVirtualizerItem.ts
@@ -22,7 +22,7 @@ interface IVirtualizer {
 export interface VirtualizerItemOptions {
   layoutInfo: LayoutInfo,
   virtualizer: IVirtualizer,
-  ref: RefObject<HTMLElement>
+  ref: RefObject<HTMLElement | null>
 }
 
 export function useVirtualizerItem(options: VirtualizerItemOptions) {

--- a/packages/@react-spectrum/autocomplete/src/SearchAutocomplete.tsx
+++ b/packages/@react-spectrum/autocomplete/src/SearchAutocomplete.tsx
@@ -195,7 +195,7 @@ let SearchAutocompleteBase = React.forwardRef(_SearchAutocompleteBase) as <T>(pr
 
 interface SearchAutocompleteInputProps<T> extends SpectrumSearchAutocompleteProps<T> {
   inputProps: InputHTMLAttributes<HTMLInputElement>,
-  inputRef: RefObject<HTMLInputElement>,
+  inputRef: RefObject<HTMLInputElement | null>,
   style?: React.CSSProperties,
   className?: string,
   isOpen?: boolean,
@@ -294,7 +294,7 @@ function _SearchAutocompleteInput<T>(props: SearchAutocompleteInputProps<T>, ref
   }, [isLoading, showLoading, inputValue]);
 
   return (
-    <FocusRing
+    (<FocusRing
       within
       isTextInput
       focusClass={classNames(styles, 'is-focused')}
@@ -302,7 +302,7 @@ function _SearchAutocompleteInput<T>(props: SearchAutocompleteInputProps<T>, ref
       autoFocus={autoFocus}>
       <div
         {...hoverProps}
-        ref={ref as RefObject<HTMLDivElement>}
+        ref={ref as RefObject<HTMLDivElement | null>}
         style={style}
         className={
           classNames(
@@ -359,7 +359,7 @@ function _SearchAutocompleteInput<T>(props: SearchAutocompleteInputProps<T>, ref
           wrapperChildren={(inputValue !== '' || loadingState === 'filtering' || validationState != null) && !isReadOnly ? clearButton : undefined}
           disableFocusRing />
       </div>
-    </FocusRing>
+    </FocusRing>)
   );
 }
 

--- a/packages/@react-spectrum/breadcrumbs/src/Breadcrumbs.tsx
+++ b/packages/@react-spectrum/breadcrumbs/src/Breadcrumbs.tsx
@@ -39,7 +39,7 @@ function Breadcrumbs<T>(props: SpectrumBreadcrumbsProps<T>, ref: DOMRef) {
   } = props;
 
   // Not using React.Children.toArray because it mutates the key prop.
-  let childArray: ReactElement[] = [];
+  let childArray: ReactElement<any>[] = [];
   React.Children.forEach(children, (child, index) => {
     if (React.isValidElement(child)) {
       if (child.key == null) {

--- a/packages/@react-spectrum/button/src/FieldButton.tsx
+++ b/packages/@react-spectrum/button/src/FieldButton.tsx
@@ -42,7 +42,7 @@ function FieldButton(props: FieldButtonProps, ref: FocusableRef) {
     focusRingClass,
     ...otherProps
   } = props;
-  let domRef = useFocusableRef(ref) as RefObject<HTMLButtonElement>;
+  let domRef = useFocusableRef(ref) as RefObject<HTMLButtonElement | null>;
   let {buttonProps, isPressed} = useButton(props, domRef);
   let {hoverProps, isHovered} = useHover({isDisabled});
   let {styleProps} = useStyleProps(otherProps);

--- a/packages/@react-spectrum/buttongroup/src/ButtonGroup.tsx
+++ b/packages/@react-spectrum/buttongroup/src/ButtonGroup.tsx
@@ -74,7 +74,7 @@ function ButtonGroup(props: SpectrumButtonGroupProps, ref: DOMRef<HTMLDivElement
   }, [checkForOverflow]);
 
   // 2. External changes: buttongroup won't change size due to any parents changing size, so listen to its container for size changes to figure out if we should remeasure
-  let parent = useRef<HTMLElement>();
+  let parent = useRef<HTMLElement>(undefined);
   useLayoutEffect(() => {
     if (domRef.current) {
       parent.current = domRef.current.parentElement as HTMLElement;

--- a/packages/@react-spectrum/calendar/src/Calendar.tsx
+++ b/packages/@react-spectrum/calendar/src/Calendar.tsx
@@ -34,7 +34,7 @@ function Calendar<T extends DateValue>(props: SpectrumCalendarProps<T>, ref: Foc
     createCalendar
   });
 
-  let domRef = useRef();
+  let domRef = useRef(undefined);
   useImperativeHandle(ref, () => ({
     ...createDOMRef(domRef),
     focus() {

--- a/packages/@react-spectrum/calendar/src/CalendarBase.tsx
+++ b/packages/@react-spectrum/calendar/src/CalendarBase.tsx
@@ -34,7 +34,7 @@ interface CalendarBaseProps<T extends CalendarState | RangeCalendarState> extend
   nextButtonProps: AriaButtonProps,
   prevButtonProps: AriaButtonProps,
   errorMessageProps: HTMLAttributes<HTMLElement>,
-  calendarRef: RefObject<HTMLDivElement>
+  calendarRef: RefObject<HTMLDivElement | null>
 }
 
 export function CalendarBase<T extends CalendarState | RangeCalendarState>(props: CalendarBaseProps<T>) {

--- a/packages/@react-spectrum/calendar/src/CalendarCell.tsx
+++ b/packages/@react-spectrum/calendar/src/CalendarCell.tsx
@@ -27,7 +27,7 @@ interface CalendarCellProps extends AriaCalendarCellProps {
 }
 
 export function CalendarCell({state, currentMonth, ...props}: CalendarCellProps) {
-  let ref = useRef<HTMLElement>();
+  let ref = useRef<HTMLElement>(undefined);
   let {
     cellProps,
     buttonProps,

--- a/packages/@react-spectrum/calendar/src/RangeCalendar.tsx
+++ b/packages/@react-spectrum/calendar/src/RangeCalendar.tsx
@@ -34,7 +34,7 @@ function RangeCalendar<T extends DateValue>(props: SpectrumRangeCalendarProps<T>
     createCalendar
   });
 
-  let domRef = useRef();
+  let domRef = useRef(undefined);
   useImperativeHandle(ref, () => ({
     ...createDOMRef(domRef),
     focus() {

--- a/packages/@react-spectrum/card/src/CardBase.tsx
+++ b/packages/@react-spectrum/card/src/CardBase.tsx
@@ -49,7 +49,7 @@ function CardBase<T extends object>(props: CardBaseProps<T>, ref: DOMRef<HTMLDiv
   let {styleProps} = useStyleProps(props);
   let {cardProps, titleProps, contentProps} = useCard(props);
   let domRef = useDOMRef(ref);
-  let gridRef = useRef<HTMLDivElement>();
+  let gridRef = useRef<HTMLDivElement>(undefined);
   let checkboxRef = useRef(null);
 
   // cards are only interactive if there is a selection manager and it allows selection

--- a/packages/@react-spectrum/card/src/CardView.tsx
+++ b/packages/@react-spectrum/card/src/CardView.tsx
@@ -185,8 +185,8 @@ function InternalCard(props) {
   let {state, cardOrientation, isQuiet, layout} = useCardViewContext();
 
   let layoutType = layout.layoutType;
-  let rowRef = useRef();
-  let cellRef = useRef<DOMRefValue<HTMLDivElement>>();
+  let rowRef = useRef(undefined);
+  let cellRef = useRef<DOMRefValue<HTMLDivElement>>(undefined);
   let unwrappedRef = useUnwrapDOMRef(cellRef);
 
   let {rowProps: gridRowProps} = useGridRow({

--- a/packages/@react-spectrum/combobox/src/ComboBox.tsx
+++ b/packages/@react-spectrum/combobox/src/ComboBox.tsx
@@ -89,14 +89,14 @@ const ComboBoxBase = React.forwardRef(function ComboBoxBase<T extends object>(pr
 
   let stringFormatter = useLocalizedStringFormatter(intlMessages, '@react-spectrum/combobox');
   let isAsync = loadingState != null;
-  let popoverRef = useRef<DOMRefValue<HTMLDivElement>>();
+  let popoverRef = useRef<DOMRefValue<HTMLDivElement>>(undefined);
   let unwrappedPopoverRef = useUnwrapDOMRef(popoverRef);
-  let buttonRef = useRef<FocusableRefValue<HTMLElement>>();
+  let buttonRef = useRef<FocusableRefValue<HTMLElement>>(undefined);
   let unwrappedButtonRef = useUnwrapDOMRef(buttonRef);
-  let listBoxRef = useRef();
-  let inputRef = useRef<HTMLInputElement>();
+  let listBoxRef = useRef(undefined);
+  let inputRef = useRef<HTMLInputElement>(undefined);
   // serve as the new popover `triggerRef` instead of `unwrappedButtonRef` before for better positioning.
-  let inputGroupRef = useRef<HTMLDivElement>();
+  let inputGroupRef = useRef<HTMLDivElement>(undefined);
   let domRef = useFocusableRef(ref, inputRef);
 
   let {contains} = useFilter({sensitivity: 'base'});
@@ -206,15 +206,15 @@ const ComboBoxBase = React.forwardRef(function ComboBoxBase<T extends object>(pr
 
 interface ComboBoxInputProps extends SpectrumComboBoxProps<unknown> {
   inputProps: InputHTMLAttributes<HTMLInputElement>,
-  inputRef: RefObject<HTMLInputElement | HTMLTextAreaElement>,
+  inputRef: RefObject<HTMLInputElement | HTMLTextAreaElement | null>,
   triggerProps: AriaButtonProps,
-  triggerRef: RefObject<FocusableRefValue<HTMLElement>>,
+  triggerRef: RefObject<FocusableRefValue<HTMLElement> | null>,
   style?: React.CSSProperties,
   className?: string,
   isOpen?: boolean
 }
 
-const ComboBoxInput = React.forwardRef(function ComboBoxInput(props: ComboBoxInputProps, ref: RefObject<HTMLElement>) {
+const ComboBoxInput = React.forwardRef(function ComboBoxInput(props: ComboBoxInputProps, ref: RefObject<HTMLElement | null>) {
   let {
     isQuiet,
     isDisabled,
@@ -279,7 +279,7 @@ const ComboBoxInput = React.forwardRef(function ComboBoxInput(props: ComboBoxInp
   }, [isLoading, showLoading, inputValue]);
 
   return (
-    <FocusRing
+    (<FocusRing
       within
       isTextInput
       focusClass={classNames(styles, 'is-focused')}
@@ -287,7 +287,7 @@ const ComboBoxInput = React.forwardRef(function ComboBoxInput(props: ComboBoxInp
       autoFocus={autoFocus}>
       <div
         {...hoverProps}
-        ref={ref as RefObject<HTMLDivElement>}
+        ref={ref as RefObject<HTMLDivElement | null>}
         style={style}
         className={
           classNames(
@@ -347,7 +347,7 @@ const ComboBoxInput = React.forwardRef(function ComboBoxInput(props: ComboBoxInp
           </FieldButton>
         </PressResponder>
       </div>
-    </FocusRing>
+    </FocusRing>)
   );
 });
 

--- a/packages/@react-spectrum/combobox/src/MobileComboBox.tsx
+++ b/packages/@react-spectrum/combobox/src/MobileComboBox.tsx
@@ -73,7 +73,7 @@ export const MobileComboBox = React.forwardRef(function MobileComboBox<T extends
     shouldCloseOnBlur: false
   });
 
-  let buttonRef = useRef<HTMLElement>();
+  let buttonRef = useRef<HTMLElement>(undefined);
   let domRef = useFocusableRef(ref, buttonRef);
   let {triggerProps, overlayProps} = useOverlayTrigger({type: 'listbox'}, state, buttonRef);
 
@@ -166,7 +166,7 @@ interface ComboBoxButtonProps extends AriaButtonProps {
   className?: string
 }
 
-const ComboBoxButton = React.forwardRef(function ComboBoxButton(props: ComboBoxButtonProps, ref: RefObject<HTMLElement>) {
+const ComboBoxButton = React.forwardRef(function ComboBoxButton(props: ComboBoxButtonProps, ref: RefObject<HTMLElement | null>) {
   let {
     isQuiet,
     isDisabled,
@@ -207,13 +207,13 @@ const ComboBoxButton = React.forwardRef(function ComboBoxButton(props: ComboBoxB
   }, ref);
 
   return (
-    <FocusRing
+    (<FocusRing
       focusClass={classNames(styles, 'is-focused')}
       focusRingClass={classNames(styles, 'focus-ring')}>
       <div
         {...mergeProps(hoverProps, buttonProps)}
         aria-haspopup="dialog"
-        ref={ref as RefObject<HTMLDivElement>}
+        ref={ref as RefObject<HTMLDivElement | null>}
         style={{...style, outline: 'none'}}
         className={
           classNames(
@@ -303,7 +303,7 @@ const ComboBoxButton = React.forwardRef(function ComboBoxButton(props: ComboBoxB
           <ChevronDownMedium UNSAFE_className={classNames(styles, 'spectrum-Dropdown-chevron')} />
         </div>
       </div>
-    </FocusRing>
+    </FocusRing>)
   );
 });
 
@@ -329,10 +329,10 @@ function ComboBoxTray(props: ComboBoxTrayProps) {
 
   let timeout = useRef(null);
   let [showLoading, setShowLoading] = useState(false);
-  let inputRef = useRef<HTMLInputElement>();
-  let buttonRef = useRef<FocusableRefValue<HTMLElement>>();
-  let popoverRef = useRef<HTMLDivElement>();
-  let listBoxRef = useRef<HTMLDivElement>();
+  let inputRef = useRef<HTMLInputElement>(undefined);
+  let buttonRef = useRef<FocusableRefValue<HTMLElement>>(undefined);
+  let popoverRef = useRef<HTMLDivElement>(undefined);
+  let listBoxRef = useRef<HTMLDivElement>(undefined);
   let isLoading = loadingState === 'loading' || loadingState === 'loadingMore';
   let layout = useListBoxLayout(state, isLoading);
   let stringFormatter = useLocalizedStringFormatter(intlMessages, '@react-spectrum/combobox');

--- a/packages/@react-spectrum/datepicker/src/DatePicker.tsx
+++ b/packages/@react-spectrum/datepicker/src/DatePicker.tsx
@@ -50,7 +50,7 @@ function DatePicker<T extends DateValue>(props: SpectrumDatePickerProps<T>, ref:
     pageBehavior
   } = props;
   let {hoverProps, isHovered} = useHover({isDisabled});
-  let targetRef = useRef<HTMLDivElement>();
+  let targetRef = useRef<HTMLDivElement>(undefined);
   let state = useDatePickerState({
     ...props,
     shouldCloseOnSelect: () => !state.hasTime

--- a/packages/@react-spectrum/datepicker/src/DatePickerField.tsx
+++ b/packages/@react-spectrum/datepicker/src/DatePickerField.tsx
@@ -33,7 +33,7 @@ export function DatePickerField<T extends DateValue>(props: DatePickerFieldProps
     isRequired,
     inputClassName
   } = props;
-  let ref = useRef();
+  let ref = useRef(undefined);
   let {locale} = useLocale();
   let state = useDateFieldState({
     ...props,
@@ -41,7 +41,7 @@ export function DatePickerField<T extends DateValue>(props: DatePickerFieldProps
     createCalendar
   });
 
-  let inputRef = useRef();
+  let inputRef = useRef(undefined);
   let {fieldProps, inputProps} = useDateField({...props, inputRef}, state, ref);
 
   return (

--- a/packages/@react-spectrum/datepicker/src/DatePickerSegment.tsx
+++ b/packages/@react-spectrum/datepicker/src/DatePickerSegment.tsx
@@ -50,7 +50,7 @@ function LiteralSegment({segment}: LiteralSegmentProps) {
 }
 
 function EditableSegment({segment, state}: DatePickerSegmentProps) {
-  let ref = useRef();
+  let ref = useRef(undefined);
   let {segmentProps} = useDateSegment(segment, state, ref);
   return (
     <div

--- a/packages/@react-spectrum/datepicker/src/DateRangePicker.tsx
+++ b/packages/@react-spectrum/datepicker/src/DateRangePicker.tsx
@@ -50,7 +50,7 @@ function DateRangePicker<T extends DateValue>(props: SpectrumDateRangePickerProp
     pageBehavior
   } = props;
   let {hoverProps, isHovered} = useHover({isDisabled});
-  let targetRef = useRef<HTMLDivElement>();
+  let targetRef = useRef<HTMLDivElement>(undefined);
   let state = useDateRangePickerState({
     ...props,
     shouldCloseOnSelect: () => !state.hasTime

--- a/packages/@react-spectrum/datepicker/src/utils.ts
+++ b/packages/@react-spectrum/datepicker/src/utils.ts
@@ -68,7 +68,7 @@ function getVisibleMonths(scale) {
 }
 
 export function useFocusManagerRef(ref: FocusableRef<HTMLElement>) {
-  let domRef = useRef();
+  let domRef = useRef(undefined);
   useImperativeHandle(ref, () => ({
     ...createDOMRef(domRef),
     focus() {

--- a/packages/@react-spectrum/dnd/src/useDragAndDrop.ts
+++ b/packages/@react-spectrum/dnd/src/useDragAndDrop.ts
@@ -43,16 +43,16 @@ interface DraggableCollectionStateOpts extends Omit<DraggableCollectionStateOpti
 
 interface DragHooks {
   useDraggableCollectionState?: (props: DraggableCollectionStateOpts) => DraggableCollectionState,
-  useDraggableCollection?: (props: DraggableCollectionOptions, state: DraggableCollectionState, ref: RefObject<HTMLElement>) => void,
+  useDraggableCollection?: (props: DraggableCollectionOptions, state: DraggableCollectionState, ref: RefObject<HTMLElement | null>) => void,
   useDraggableItem?: (props: DraggableItemProps, state: DraggableCollectionState) => DraggableItemResult,
   DragPreview?: typeof DragPreview
 }
 
 interface DropHooks {
   useDroppableCollectionState?: (props: DroppableCollectionStateOptions) => DroppableCollectionState,
-  useDroppableCollection?: (props: DroppableCollectionOptions, state: DroppableCollectionState, ref: RefObject<HTMLElement>) => DroppableCollectionResult,
-  useDroppableItem?: (options: DroppableItemOptions, state: DroppableCollectionState, ref: RefObject<HTMLElement>) => DroppableItemResult,
-  useDropIndicator?: (props: DropIndicatorProps, state: DroppableCollectionState, ref: RefObject<HTMLElement>) => DropIndicatorAria
+  useDroppableCollection?: (props: DroppableCollectionOptions, state: DroppableCollectionState, ref: RefObject<HTMLElement | null>) => DroppableCollectionResult,
+  useDroppableItem?: (options: DroppableItemOptions, state: DroppableCollectionState, ref: RefObject<HTMLElement | null>) => DroppableItemResult,
+  useDropIndicator?: (props: DropIndicatorProps, state: DroppableCollectionState, ref: RefObject<HTMLElement | null>) => DropIndicatorAria
 }
 
 export interface DragAndDropHooks {
@@ -104,7 +104,7 @@ export function useDragAndDrop(options: DragAndDropOptions): DragAndDropHooks {
         return useDroppableCollectionState({...props, ...options});
       };
       hooks.useDroppableItem = useDroppableItem;
-      hooks.useDroppableCollection = function useDroppableCollectionOverride(props: DroppableCollectionOptions, state: DroppableCollectionState, ref: RefObject<HTMLElement>) {
+      hooks.useDroppableCollection = function useDroppableCollectionOverride(props: DroppableCollectionOptions, state: DroppableCollectionState, ref: RefObject<HTMLElement | null>) {
         return useDroppableCollection({...props, ...options}, state, ref);
       };
       hooks.useDropIndicator = useDropIndicator;

--- a/packages/@react-spectrum/icon/src/Icon.tsx
+++ b/packages/@react-spectrum/icon/src/Icon.tsx
@@ -25,7 +25,7 @@ export interface IconProps extends DOMProps, AriaLabelingProps, StyleProps {
   /**
    * The content to display. Should be an SVG.
    */
-  children: ReactElement,
+  children: ReactElement<any>,
   /**
    * Size of Icon (changes based on scale).
    */

--- a/packages/@react-spectrum/icon/src/Illustration.tsx
+++ b/packages/@react-spectrum/icon/src/Illustration.tsx
@@ -23,7 +23,7 @@ export interface IllustrationProps extends DOMProps, AriaLabelingProps, StylePro
   /**
    * The content to display. Should be an SVG.
    */
-  children: ReactElement,
+  children: ReactElement<any>,
   /**
    * A slot to place the illustration in.
    * @default 'illustration'

--- a/packages/@react-spectrum/icon/src/UIIcon.tsx
+++ b/packages/@react-spectrum/icon/src/UIIcon.tsx
@@ -18,7 +18,7 @@ import styles from '@adobe/spectrum-css-temp/components/icon/vars.css';
 import {useProvider} from '@react-spectrum/provider';
 
 export interface UIIconProps extends DOMProps, AriaLabelingProps, StyleProps {
-  children: ReactElement,
+  children: ReactElement<any>,
   slot?: string,
   /**
    * Indicates whether the element is exposed to an accessibility API.

--- a/packages/@react-spectrum/label/src/Field.tsx
+++ b/packages/@react-spectrum/label/src/Field.tsx
@@ -165,14 +165,14 @@ function Field(props: SpectrumFieldProps, ref: Ref<HTMLElement>) {
   }
 
   return (
-    <div
+    (<div
       {...styleProps}
       {...wrapperProps}
-      ref={ref as RefObject<HTMLDivElement>}
+      ref={ref as RefObject<HTMLDivElement | null>}
       className={labelWrapperClass}>
       {labelAndContextualHelp}
       {renderChildren()}
-    </div>
+    </div>)
   );
 }
 

--- a/packages/@react-spectrum/list/src/InsertionIndicator.tsx
+++ b/packages/@react-spectrum/list/src/InsertionIndicator.tsx
@@ -14,7 +14,7 @@ export default function InsertionIndicator(props: InsertionIndicatorProps) {
   let {dropState, dragAndDropHooks} = useContext(ListViewContext);
   const {target, isPresentationOnly} = props;
 
-  let ref = useRef();
+  let ref = useRef(undefined);
   let {dropIndicatorProps} = dragAndDropHooks.useDropIndicator(props, dropState, ref);
   let {visuallyHiddenProps} = useVisuallyHidden();
 

--- a/packages/@react-spectrum/list/src/ListViewItem.tsx
+++ b/packages/@react-spectrum/list/src/ListViewItem.tsx
@@ -53,8 +53,8 @@ export function ListViewItem<T>(props: ListViewItemProps<T>) {
     loadingState
   } = useContext(ListViewContext);
   let {direction} = useLocale();
-  let rowRef = useRef<HTMLDivElement>();
-  let checkboxWrapperRef = useRef<HTMLDivElement>();
+  let rowRef = useRef<HTMLDivElement>(undefined);
+  let checkboxWrapperRef = useRef<HTMLDivElement>(undefined);
   let {
     isFocusVisible: isFocusVisibleWithin,
     focusProps: focusWithinProps
@@ -91,7 +91,7 @@ export function ListViewItem<T>(props: ListViewItemProps<T>) {
   let droppableItem: DroppableItemResult;
   let isDropTarget: boolean;
   let dropIndicator: DropIndicatorAria;
-  let dropIndicatorRef = useRef();
+  let dropIndicatorRef = useRef(undefined);
   if (isListDroppable) {
     let target = {type: 'item', key: item.key, dropPosition: 'on'} as DropTarget;
     isDropTarget = dropState.isDropTarget(target);
@@ -99,7 +99,7 @@ export function ListViewItem<T>(props: ListViewItemProps<T>) {
     dropIndicator = dragAndDropHooks.useDropIndicator({target}, dropState, dropIndicatorRef);
   }
 
-  let dragButtonRef = React.useRef();
+  let dragButtonRef = React.useRef(undefined);
   let {buttonProps} = useButton({
     ...draggableItem?.dragButtonProps,
     elementType: 'div'

--- a/packages/@react-spectrum/list/src/RootDropIndicator.tsx
+++ b/packages/@react-spectrum/list/src/RootDropIndicator.tsx
@@ -4,7 +4,7 @@ import {useVisuallyHidden} from '@react-aria/visually-hidden';
 
 export default function RootDropIndicator() {
   let {dropState, dragAndDropHooks} = useContext(ListViewContext);
-  let ref = useRef();
+  let ref = useRef(undefined);
   let {dropIndicatorProps} = dragAndDropHooks.useDropIndicator({
     target: {type: 'root'}
   }, dropState, ref);

--- a/packages/@react-spectrum/listbox/src/ListBoxBase.tsx
+++ b/packages/@react-spectrum/listbox/src/ListBoxBase.tsx
@@ -76,7 +76,7 @@ export function useListBoxLayout<T>(state: ListState<T>, isLoading: boolean): Li
 }
 
 /** @private */
-function ListBoxBase<T>(props: ListBoxBaseProps<T>, ref: RefObject<HTMLDivElement>) {
+function ListBoxBase<T>(props: ListBoxBaseProps<T>, ref: RefObject<HTMLDivElement | null>) {
   let {layout, state, shouldSelectOnPressUp, focusOnPointerEnter, shouldUseVirtualFocus, domProps = {}, transitionDuration = 0, onScroll} = props;
   let {listBoxProps} = useListBox({
     ...props,
@@ -115,7 +115,7 @@ function ListBoxBase<T>(props: ListBoxBaseProps<T>, ref: RefObject<HTMLDivElemen
   };
 
   return (
-    <ListBoxContext.Provider value={state}>
+    (<ListBoxContext.Provider value={state}>
       <FocusScope>
         <Virtualizer
           {...styleProps}
@@ -153,13 +153,13 @@ function ListBoxBase<T>(props: ListBoxBaseProps<T>, ref: RefObject<HTMLDivElemen
               return (
                 // aria-selected isn't needed here since this option is not selectable.
                 // eslint-disable-next-line jsx-a11y/role-has-required-aria-props
-                <div role="option" style={{display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%'}}>
+                (<div role="option" style={{display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%'}}>
                   <ProgressCircle
                     isIndeterminate
                     size="S"
                     aria-label={state.collection.size > 0 ? stringFormatter.format('loadingMore') : stringFormatter.format('loading')}
                     UNSAFE_className={classNames(styles, 'spectrum-Dropdown-progressCircle')} />
-                </div>
+                </div>)
               );
             } else if (type === 'placeholder') {
               let emptyState = props.renderEmptyState ? props.renderEmptyState() : null;
@@ -179,11 +179,11 @@ function ListBoxBase<T>(props: ListBoxBaseProps<T>, ref: RefObject<HTMLDivElemen
           }}
         </Virtualizer>
       </FocusScope>
-    </ListBoxContext.Provider>
+    </ListBoxContext.Provider>)
   );
 }
 
 // forwardRef doesn't support generic parameters, so cast the result to the correct type
 // https://stackoverflow.com/questions/58469229/react-with-typescript-generics-while-using-react-forwardref
-const _ListBoxBase = React.forwardRef(ListBoxBase) as <T>(props: ListBoxBaseProps<T> & {ref?: RefObject<HTMLDivElement>}) => ReactElement;
+const _ListBoxBase = React.forwardRef(ListBoxBase) as <T>(props: ListBoxBaseProps<T> & {ref?: RefObject<HTMLDivElement | null>}) => ReactElement;
 export {_ListBoxBase as ListBoxBase};

--- a/packages/@react-spectrum/listbox/src/ListBoxOption.tsx
+++ b/packages/@react-spectrum/listbox/src/ListBoxOption.tsx
@@ -46,7 +46,7 @@ export function ListBoxOption<T>(props: OptionProps<T>) {
   let ElementType: React.ElementType = item.props.href ? 'a' : 'div';
   let state = useContext(ListBoxContext);
 
-  let ref = useRef<any>();
+  let ref = useRef<any>(undefined);
   let {optionProps, labelProps, descriptionProps, isSelected, isDisabled, isFocused} = useOption(
     {
       'aria-label': item['aria-label'],

--- a/packages/@react-spectrum/listbox/src/ListBoxSection.tsx
+++ b/packages/@react-spectrum/listbox/src/ListBoxSection.tsx
@@ -34,7 +34,7 @@ export function ListBoxSection<T>(props: ListBoxSectionProps<T>) {
     'aria-label': item['aria-label']
   });
 
-  let headerRef = useRef();
+  let headerRef = useRef(undefined);
   useVirtualizerItem({
     layoutInfo: headerLayoutInfo,
     virtualizer,

--- a/packages/@react-spectrum/menu/src/ContextualHelpTrigger.tsx
+++ b/packages/@react-spectrum/menu/src/ContextualHelpTrigger.tsx
@@ -183,7 +183,7 @@ ContextualHelpTrigger.getCollectionNode = function* getCollectionNode<T>(props: 
   let [, content] = props.children as [ReactElement, ReactElement];
 
   yield {
-    element: React.cloneElement(trigger, {...trigger.props, hasChildItems: true, isTrigger: true}),
+    element: React.cloneElement(trigger, {...trigger.props as any, hasChildItems: true, isTrigger: true}),
     wrapper: (element) => (
       <ContextualHelpTrigger key={element.key} targetKey={element.key} {...props}>
         {element}

--- a/packages/@react-spectrum/menu/src/MenuTrigger.tsx
+++ b/packages/@react-spectrum/menu/src/MenuTrigger.tsx
@@ -23,10 +23,10 @@ import {useMenuTrigger} from '@react-aria/menu';
 import {useMenuTriggerState} from '@react-stately/menu';
 
 function MenuTrigger(props: SpectrumMenuTriggerProps, ref: DOMRef<HTMLElement>) {
-  let triggerRef = useRef<HTMLElement>();
+  let triggerRef = useRef<HTMLElement>(undefined);
   let domRef = useDOMRef(ref);
   let menuTriggerRef = domRef || triggerRef;
-  let menuRef = useRef<HTMLDivElement>();
+  let menuRef = useRef<HTMLDivElement>(undefined);
   let {
     children,
     align = 'start',

--- a/packages/@react-spectrum/menu/src/SubmenuTrigger.tsx
+++ b/packages/@react-spectrum/menu/src/SubmenuTrigger.tsx
@@ -15,7 +15,7 @@ import {Key} from '@react-types/shared';
 import {MenuContext, SubmenuTriggerContext, useMenuStateContext} from './context';
 import {mergeProps, useLayoutEffect} from '@react-aria/utils';
 import {Popover} from '@react-spectrum/overlays';
-import React, {ReactElement, useRef, useState} from 'react';
+import React, { ReactElement, useRef, useState, type JSX } from 'react';
 import ReactDOM from 'react-dom';
 import styles from '@adobe/spectrum-css-temp/components/menu/vars.css';
 import {UNSTABLE_useSubmenuTrigger} from '@react-aria/menu';
@@ -33,7 +33,7 @@ interface SubmenuTriggerProps {
 export interface SpectrumSubmenuTriggerProps extends Omit<SubmenuTriggerProps, 'targetKey'> {}
 
 function SubmenuTrigger(props: SubmenuTriggerProps) {
-  let triggerRef = useRef<HTMLDivElement>();
+  let triggerRef = useRef<HTMLDivElement>(undefined);
   let {
     children,
     targetKey

--- a/packages/@react-spectrum/menu/src/SubmenuTrigger.tsx
+++ b/packages/@react-spectrum/menu/src/SubmenuTrigger.tsx
@@ -153,7 +153,7 @@ SubmenuTrigger.getCollectionNode = function* (props: SpectrumSubmenuTriggerProps
   let [, content] = props.children as [ReactElement, ReactElement];
 
   yield {
-    element: React.cloneElement(trigger, {...trigger.props, hasChildItems: true, isTrigger: true}),
+    element: React.cloneElement(trigger, {...trigger.props as any, hasChildItems: true, isTrigger: true}),
     wrapper: (element) => (
       <SubmenuTrigger key={element.key} targetKey={element.key} {...props}>
         {element}

--- a/packages/@react-spectrum/menu/src/context.ts
+++ b/packages/@react-spectrum/menu/src/context.ts
@@ -50,9 +50,9 @@ export function useSubmenuTriggerContext(): SubmenuTriggerContextValue {
 export interface MenuStateContextValue<T> {
   state?: TreeState<T>,
   popoverContainer?: HTMLElement,
-  trayContainerRef?: RefObject<HTMLElement>,
-  menu?: RefObject<HTMLDivElement>,
-  submenu?: RefObject<HTMLDivElement>,
+  trayContainerRef?: RefObject<HTMLElement | null>,
+  menu?: RefObject<HTMLDivElement | null>,
+  submenu?: RefObject<HTMLDivElement | null>,
   rootMenuTriggerState?: RootMenuTriggerState
 }
 

--- a/packages/@react-spectrum/numberfield/src/NumberField.tsx
+++ b/packages/@react-spectrum/numberfield/src/NumberField.tsx
@@ -116,7 +116,7 @@ function NumberField(props: SpectrumNumberFieldProps, ref: FocusableRef<HTMLElem
 interface NumberFieldInputProps extends SpectrumNumberFieldProps {
   groupProps: HTMLAttributes<HTMLDivElement>,
   inputProps: InputHTMLAttributes<HTMLInputElement>,
-  inputRef: RefObject<HTMLInputElement | HTMLTextAreaElement>,
+  inputRef: RefObject<HTMLInputElement | HTMLTextAreaElement | null>,
   incrementProps: AriaButtonProps,
   decrementProps: AriaButtonProps,
   className?: string,

--- a/packages/@react-spectrum/overlays/src/Modal.tsx
+++ b/packages/@react-spectrum/overlays/src/Modal.tsx
@@ -52,7 +52,7 @@ let typeMap = {
   fullscreenTakeover: 'fullscreenTakeover'
 };
 
-let ModalWrapper = forwardRef(function (props: ModalWrapperProps, ref: RefObject<HTMLDivElement>) {
+let ModalWrapper = forwardRef(function (props: ModalWrapperProps, ref: RefObject<HTMLDivElement | null>) {
   let {type, children, state, isOpen, wrapperRef} = props;
   let typeVariant = typeMap[type];
   let {styleProps} = useStyleProps(props);

--- a/packages/@react-spectrum/overlays/src/Popover.tsx
+++ b/packages/@react-spectrum/overlays/src/Popover.tsx
@@ -47,7 +47,7 @@ interface PopoverWrapperProps extends PopoverProps, FocusWithinProps {
 interface ArrowProps {
   arrowProps: PopoverAria['arrowProps'],
   isLandscape: boolean,
-  arrowRef?: RefObject<SVGSVGElement>,
+  arrowRef?: RefObject<SVGSVGElement | null>,
   primary: number,
   secondary: number,
   borderDiagonal: number
@@ -85,7 +85,7 @@ function Popover(props: PopoverProps, ref: DOMRef<HTMLDivElement>) {
   );
 }
 
-const PopoverWrapper = forwardRef((props: PopoverWrapperProps, ref: RefObject<HTMLDivElement>) => {
+const PopoverWrapper = forwardRef((props: PopoverWrapperProps, ref: RefObject<HTMLDivElement | null>) => {
   let {
     children,
     isOpen,
@@ -166,7 +166,7 @@ const PopoverWrapper = forwardRef((props: PopoverWrapperProps, ref: RefObject<HT
   );
 });
 
-function usePopoverBorderRadius(popoverRef: RefObject<HTMLDivElement>) {
+function usePopoverBorderRadius(popoverRef: RefObject<HTMLDivElement | null>) {
   let [borderRadius, setBorderRadius] = useState(0);
   useLayoutEffect(() => {
     if (popoverRef.current) {

--- a/packages/@react-spectrum/overlays/src/Tray.tsx
+++ b/packages/@react-spectrum/overlays/src/Tray.tsx
@@ -47,7 +47,7 @@ function Tray(props: TrayProps, ref: DOMRef<HTMLDivElement>) {
   );
 }
 
-let TrayWrapper = forwardRef(function (props: TrayWrapperProps, ref: RefObject<HTMLDivElement>) {
+let TrayWrapper = forwardRef(function (props: TrayWrapperProps, ref: RefObject<HTMLDivElement | null>) {
   let {
     children,
     isOpen,

--- a/packages/@react-spectrum/picker/src/Picker.tsx
+++ b/packages/@react-spectrum/picker/src/Picker.tsx
@@ -64,10 +64,10 @@ function Picker<T extends object>(props: SpectrumPickerProps<T>, ref: DOMRef<HTM
   let state = useSelectState(props);
   let domRef = useDOMRef(ref);
 
-  let popoverRef = useRef<DOMRefValue<HTMLDivElement>>();
-  let triggerRef = useRef<FocusableRefValue<HTMLElement>>();
+  let popoverRef = useRef<DOMRefValue<HTMLDivElement>>(undefined);
+  let triggerRef = useRef<FocusableRefValue<HTMLElement>>(undefined);
   let unwrappedTriggerRef = useUnwrapDOMRef(triggerRef);
-  let listboxRef = useRef();
+  let listboxRef = useRef(undefined);
 
   let isLoadingInitial = props.isLoading && state.collection.size === 0;
   let isLoadingMore = props.isLoading && state.collection.size > 0;

--- a/packages/@react-spectrum/slider/src/SliderBase.tsx
+++ b/packages/@react-spectrum/slider/src/SliderBase.tsx
@@ -21,8 +21,8 @@ import {useProviderProps} from '@react-spectrum/provider';
 import {useSlider} from '@react-aria/slider';
 
 export interface SliderBaseChildArguments {
-  inputRef: RefObject<HTMLInputElement>,
-  trackRef: RefObject<HTMLElement>,
+  inputRef: RefObject<HTMLInputElement | null>,
+  trackRef: RefObject<HTMLElement | null>,
   state: SliderState
 }
 
@@ -74,7 +74,7 @@ function SliderBase(props: SliderBaseProps, ref: FocusableRef<HTMLDivElement>) {
     minValue,
     maxValue
   });
-  let trackRef = useRef();
+  let trackRef = useRef(undefined);
   let {
     groupProps,
     trackProps,
@@ -82,7 +82,7 @@ function SliderBase(props: SliderBaseProps, ref: FocusableRef<HTMLDivElement>) {
     outputProps
   } = useSlider(props, state, trackRef);
 
-  let inputRef = useRef();
+  let inputRef = useRef(undefined);
   let domRef = useFocusableRef(ref, inputRef);
 
   let displayValue = '';

--- a/packages/@react-spectrum/slider/src/SliderThumb.tsx
+++ b/packages/@react-spectrum/slider/src/SliderThumb.tsx
@@ -22,8 +22,8 @@ import {useSliderThumb} from '@react-aria/slider';
 import {VisuallyHidden} from '@react-aria/visually-hidden';
 
 interface SliderThumbProps extends AriaSliderThumbProps {
-  trackRef: RefObject<HTMLElement>,
-  inputRef?: RefObject<HTMLInputElement>,
+  trackRef: RefObject<HTMLElement | null>,
+  inputRef?: RefObject<HTMLInputElement | null>,
   state: SliderState
 }
 
@@ -32,7 +32,7 @@ export function SliderThumb(props: SliderThumbProps) {
     inputRef,
     state
   } = props;
-  let backupRef = useRef<HTMLInputElement>();
+  let backupRef = useRef<HTMLInputElement>(undefined);
   inputRef = inputRef || backupRef;
 
   let {thumbProps, inputProps, isDragging, isFocused} = useSliderThumb({

--- a/packages/@react-spectrum/table/src/InsertionIndicator.tsx
+++ b/packages/@react-spectrum/table/src/InsertionIndicator.tsx
@@ -26,7 +26,7 @@ export function InsertionIndicator(props: InsertionIndicatorProps) {
   let {dropState, dragAndDropHooks} = useTableContext();
   const {target, rowProps} = props;
 
-  let ref = useRef();
+  let ref = useRef(undefined);
   let {dropIndicatorProps} = dragAndDropHooks.useDropIndicator(props, dropState, ref);
   let {visuallyHiddenProps} = useVisuallyHidden();
 

--- a/packages/@react-spectrum/table/src/Resizer.tsx
+++ b/packages/@react-spectrum/table/src/Resizer.tsx
@@ -34,7 +34,7 @@ function getCursor(svg: string, fallback: string) {
 interface ResizerProps<T> {
   column: GridNode<T>,
   showResizer: boolean,
-  triggerRef: RefObject<HTMLDivElement>,
+  triggerRef: RefObject<HTMLDivElement | null>,
   onResizeStart: (widths: Map<Key, ColumnSize>) => void,
   onResize: (widths: Map<Key, ColumnSize>) => void,
   onResizeEnd: (widths: Map<Key, ColumnSize>) => void
@@ -46,7 +46,7 @@ const CURSORS = {
   e: getCursor(eCursor, 'e-resize')
 };
 
-function Resizer<T>(props: ResizerProps<T>, ref: RefObject<HTMLInputElement>) {
+function Resizer<T>(props: ResizerProps<T>, ref: RefObject<HTMLInputElement | null>) {
   let {column, showResizer} = props;
   let {isEmpty, layout, onFocusedResizer} = useTableContext();
   // Virtualizer re-renders, but these components are all cached

--- a/packages/@react-spectrum/table/src/RootDropIndicator.tsx
+++ b/packages/@react-spectrum/table/src/RootDropIndicator.tsx
@@ -16,7 +16,7 @@ import {useVisuallyHidden} from '@react-aria/visually-hidden';
 
 export function RootDropIndicator() {
   let {dropState, dragAndDropHooks, state} = useTableContext();
-  let ref = useRef();
+  let ref = useRef(undefined);
   let {dropIndicatorProps} = dragAndDropHooks.useDropIndicator({
     target: {type: 'root'}
   }, dropState, ref);

--- a/packages/@react-spectrum/table/src/TableViewBase.tsx
+++ b/packages/@react-spectrum/table/src/TableViewBase.tsx
@@ -201,8 +201,8 @@ function TableViewBase<T extends object>(props: TableBaseProps<T>, ref: DOMRef<H
   let [, setIsResizing] = useState(false);
 
   let domRef = useDOMRef(ref);
-  let headerRef = useRef<HTMLDivElement>();
-  let bodyRef = useRef<HTMLDivElement>();
+  let headerRef = useRef<HTMLDivElement>(undefined);
+  let bodyRef = useRef<HTMLDivElement>(undefined);
   let stringFormatter = useLocalizedStringFormatter(intlMessages, '@react-spectrum/table');
 
   let density = props.density || 'regular';
@@ -970,7 +970,7 @@ function ResizableTableColumnHeader(props) {
 }
 
 function TableSelectAllCell({column}) {
-  let ref = useRef();
+  let ref = useRef(undefined);
   let {state} = useTableContext();
   let isSingleSelectionMode = state.selectionManager.selectionMode === 'single';
   let {columnHeaderProps} = useTableColumnHeader({
@@ -1017,7 +1017,7 @@ function TableSelectAllCell({column}) {
 }
 
 function TableDragHeaderCell({column}) {
-  let ref = useRef();
+  let ref = useRef(undefined);
   let {state} = useTableContext();
   let {columnHeaderProps} = useTableColumnHeader({
     node: column,
@@ -1092,7 +1092,7 @@ export function useTableRowContext() {
 }
 
 function TableRow({item, children, hasActions, isTableDraggable, isTableDroppable, ...otherProps}) {
-  let ref = useRef();
+  let ref = useRef(undefined);
   let {state, layout, dragAndDropHooks, dragState, dropState} = useTableContext();
   let allowsInteraction = state.selectionManager.selectionMode !== 'none' || hasActions;
   let isDisabled = !allowsInteraction || state.disabledKeys.has(item.key);
@@ -1136,7 +1136,7 @@ function TableRow({item, children, hasActions, isTableDraggable, isTableDroppabl
   let droppableItem: DroppableItemResult;
   let isDropTarget: boolean;
   let dropIndicator: DropIndicatorAria;
-  let dropIndicatorRef = useRef();
+  let dropIndicatorRef = useRef(undefined);
   if (isTableDroppable) {
     let target = {type: 'item', key: item.key, dropPosition: 'on'} as DropTarget;
     isDropTarget = dropState.isDropTarget(target);
@@ -1144,7 +1144,7 @@ function TableRow({item, children, hasActions, isTableDraggable, isTableDroppabl
     dropIndicator = dragAndDropHooks.useDropIndicator({target}, dropState, dropIndicatorRef);
   }
 
-  let dragButtonRef = React.useRef();
+  let dragButtonRef = React.useRef(undefined);
   let {buttonProps: dragButtonProps} = useButton({
     ...draggableItem?.dragButtonProps,
     elementType: 'div'
@@ -1222,7 +1222,7 @@ function TableRow({item, children, hasActions, isTableDraggable, isTableDroppabl
 
 function TableHeaderRow({item, children, style, ...props}) {
   let {state, headerMenuOpen} = useTableContext();
-  let ref = useRef();
+  let ref = useRef(undefined);
   let {rowProps} = useTableHeaderRow({node: item, isVirtualized: true}, state, ref);
   let {hoverProps} = useHover({...props, isDisabled: headerMenuOpen});
 
@@ -1234,7 +1234,7 @@ function TableHeaderRow({item, children, style, ...props}) {
 }
 
 function TableDragCell({cell}) {
-  let ref = useRef();
+  let ref = useRef(undefined);
   let {state, isTableDraggable} = useTableContext();
   let isDisabled = state.disabledKeys.has(cell.parentKey);
   let {gridCellProps} = useTableCell({
@@ -1269,7 +1269,7 @@ function TableDragCell({cell}) {
 }
 
 function TableCheckboxCell({cell}) {
-  let ref = useRef();
+  let ref = useRef(undefined);
   let {state} = useTableContext();
   let isDisabled = state.disabledKeys.has(cell.parentKey);
   let {gridCellProps} = useTableCell({
@@ -1314,7 +1314,7 @@ function TableCell({cell}) {
   let {scale} = useProvider();
   let {state} = useTableContext();
   let isExpandableTable = 'expandedKeys' in state;
-  let ref = useRef();
+  let ref = useRef(undefined);
   let columnProps = cell.column.props as SpectrumColumnProps<unknown>;
   let isDisabled = state.disabledKeys.has(cell.parentKey);
   let {gridCellProps} = useTableCell({
@@ -1382,7 +1382,7 @@ function ExpandableRowChevron({cell}) {
    // TODO: move some/all of the chevron button setup into a separate hook?
   let {direction} = useLocale();
   let {state} = useTableContext();
-  let expandButtonRef = useRef();
+  let expandButtonRef = useRef(undefined);
   let stringFormatter = useLocalizedStringFormatter(intlMessages, '@react-spectrum/table');
   let isExpanded;
 

--- a/packages/@react-spectrum/table/test/TreeGridTable.test.tsx
+++ b/packages/@react-spectrum/table/test/TreeGridTable.test.tsx
@@ -306,7 +306,7 @@ describe('TableView with expandable rows', function () {
   });
 
   it('shouldn\'t render a child row if its parent isn\'t included in the expanded keys', function () {
-    let treegrid = render(<DynamicExpandableTable UNSTABLE_expandedKeys={['Lvl 2 Foo 1']} />);
+    let treegrid = render(DynamicExpandableTable({UNSTABLE_expandedKeys: ['Lvl 2 Foo 1']}, undefined));
     let rowgroups = treegrid.getAllByRole('rowgroup');
     let rows = within(rowgroups[1]).getAllByRole('row');
     expect(rows).toHaveLength(1);

--- a/packages/@react-spectrum/tabs/src/Tabs.tsx
+++ b/packages/@react-spectrum/tabs/src/Tabs.tsx
@@ -67,8 +67,8 @@ function Tabs<T extends object>(props: SpectrumTabsProps<T>, ref: DOMRef<HTMLDiv
   } = props;
 
   let domRef = useDOMRef(ref);
-  let tablistRef = useRef<HTMLDivElement>();
-  let wrapperRef = useRef<HTMLDivElement>();
+  let tablistRef = useRef<HTMLDivElement>(undefined);
+  let wrapperRef = useRef<HTMLDivElement>(undefined);
 
   let {direction} = useLocale();
   let {styleProps} = useStyleProps(otherProps);
@@ -159,7 +159,7 @@ function Tab<T>(props: TabProps<T>) {
   let {item, state} = props;
   let {key, rendered} = item;
 
-  let ref = useRef<any>();
+  let ref = useRef<any>(undefined);
   let {tabProps, isSelected, isDisabled} = useTab({key}, state, ref);
 
   let {hoverProps, isHovered} = useHover({
@@ -353,7 +353,7 @@ interface TabPanelProps extends AriaTabPanelProps, StyleProps {
 function TabPanel(props: TabPanelProps) {
   const {tabState, tabPanelProps: ctxTabPanelProps} = useContext(TabContext);
   const {tabListState} = tabState;
-  let ref = useRef();
+  let ref = useRef(undefined);
   const {tabPanelProps} = useTabPanel(props, tabListState, ref);
   let {styleProps} = useStyleProps(props);
 
@@ -392,7 +392,7 @@ function TabPicker<T>(props: TabPickerProps<T>) {
     visible
   } = props;
 
-  let ref = useRef();
+  let ref = useRef(undefined);
   let [pickerNode, setPickerNode] = useState(null);
 
   useEffect(() => {

--- a/packages/@react-spectrum/textfield/src/TextFieldBase.tsx
+++ b/packages/@react-spectrum/textfield/src/TextFieldBase.tsx
@@ -31,7 +31,7 @@ interface TextFieldBaseProps extends Omit<SpectrumTextFieldProps, 'onChange' | '
   inputProps: InputHTMLAttributes<HTMLInputElement> | TextareaHTMLAttributes<HTMLTextAreaElement>,
   descriptionProps?: HTMLAttributes<HTMLElement>,
   errorMessageProps?: HTMLAttributes<HTMLElement>,
-  inputRef?: RefObject<HTMLInputElement | HTMLTextAreaElement>,
+  inputRef?: RefObject<HTMLInputElement | HTMLTextAreaElement | null>,
   loadingIndicator?: ReactElement,
   isLoading?: boolean,
   disableFocusRing?: boolean

--- a/packages/@react-spectrum/toast/src/ToastContainer.tsx
+++ b/packages/@react-spectrum/toast/src/ToastContainer.tsx
@@ -78,7 +78,7 @@ export function ToastContainer(props: SpectrumToastContainerProps): ReactElement
   // Only the first one will actually render.
   // We use a ref to do this, since it will have a stable identity
   // over the lifetime of the component.
-  let ref = useRef();
+  let ref = useRef(undefined);
 
   // eslint-disable-next-line arrow-body-style
   useEffect(() => {

--- a/packages/@react-spectrum/toast/src/Toaster.tsx
+++ b/packages/@react-spectrum/toast/src/Toaster.tsx
@@ -33,7 +33,7 @@ export function Toaster(props: ToastContainerProps): ReactElement {
     state
   } = props;
 
-  let ref = useRef();
+  let ref = useRef(undefined);
   let {regionProps} = useToastRegion(props, state, ref);
   let {focusProps, isFocusVisible} = useFocusRing();
 

--- a/packages/@react-spectrum/toast/stories/Toast.stories.tsx
+++ b/packages/@react-spectrum/toast/stories/Toast.stories.tsx
@@ -329,7 +329,7 @@ function IframeExample() {
 }
 
 function MainLandmark(props) {
-  let ref = useRef();
+  let ref = useRef(undefined);
   let {landmarkProps} = useLandmark({...props, role: 'main'}, ref);
   return <main aria-label="Danni's unicorn corral" ref={ref} {...props} {...landmarkProps} style={{padding: 40, background: 'white'}}>{props.children}</main>;
 }

--- a/packages/@react-spectrum/tooltip/src/Tooltip.tsx
+++ b/packages/@react-spectrum/tooltip/src/Tooltip.tsx
@@ -30,7 +30,7 @@ let iconMap = {
 
 function Tooltip(props: SpectrumTooltipProps, ref: DOMRef) {
   let {ref: overlayRef, arrowProps, state, arrowRef, ...tooltipProviderProps} = useContext(TooltipContext);
-  let defaultRef = useRef();
+  let defaultRef = useRef(undefined);
   overlayRef = overlayRef || defaultRef;
   props = mergeProps(props, tooltipProviderProps);
   let {

--- a/packages/@react-spectrum/tooltip/src/TooltipTrigger.tsx
+++ b/packages/@react-spectrum/tooltip/src/TooltipTrigger.tsx
@@ -35,8 +35,8 @@ function TooltipTrigger(props: SpectrumTooltipTriggerProps) {
   let [trigger, tooltip] = React.Children.toArray(children) as [ReactElement, ReactElement];
   let state = useTooltipTriggerState(props);
 
-  let tooltipTriggerRef = useRef<HTMLElement>();
-  let overlayRef = useRef<HTMLDivElement>();
+  let tooltipTriggerRef = useRef<HTMLElement>(undefined);
+  let overlayRef = useRef<HTMLDivElement>(undefined);
 
   let {triggerProps, tooltipProps} = useTooltipTrigger({
     isDisabled,

--- a/packages/@react-spectrum/tooltip/src/context.ts
+++ b/packages/@react-spectrum/tooltip/src/context.ts
@@ -17,10 +17,10 @@ import {TooltipTriggerState} from '@react-stately/tooltip';
 
 interface TooltipContextProps extends StyleProps {
   state?: TooltipTriggerState,
-  ref?: RefObject<HTMLDivElement>,
+  ref?: RefObject<HTMLDivElement | null>,
   placement?: PlacementAxis,
   arrowProps?: HTMLAttributes<HTMLElement>,
-  arrowRef?: RefObject<HTMLElement>
+  arrowRef?: RefObject<HTMLElement | null>
 }
 
 export const TooltipContext = React.createContext<TooltipContextProps>({});

--- a/packages/@react-spectrum/tree/src/Tree.tsx
+++ b/packages/@react-spectrum/tree/src/Tree.tsx
@@ -36,7 +36,7 @@ export function Tree<T extends object>(props: CollectionBase<T> & Expandable & M
     })
   , []);
 
-  let ref = useRef();
+  let ref = useRef(undefined);
   let {collectionProps} = useSelectableCollection({
     ref,
     selectionManager: state.selectionManager,
@@ -89,7 +89,7 @@ function TreeItem<T>(props: TreeItemProps<T>) {
     // 'is-drop-target': isDropTarget
   });
 
-  let ref = useRef<HTMLDivElement>();
+  let ref = useRef<HTMLDivElement>(undefined);
   let {itemProps} = useSelectableItem({
     selectionManager: state.selectionManager,
     key: item.key,

--- a/packages/@react-spectrum/utils/src/useDOMRef.ts
+++ b/packages/@react-spectrum/utils/src/useDOMRef.ts
@@ -13,7 +13,7 @@
 import {DOMRef, DOMRefValue, FocusableElement, FocusableRef, FocusableRefValue} from '@react-types/shared';
 import {RefObject, useImperativeHandle, useMemo, useRef} from 'react';
 
-export function createDOMRef<T extends HTMLElement = HTMLElement>(ref: RefObject<T>): DOMRefValue<T> {
+export function createDOMRef<T extends HTMLElement = HTMLElement>(ref: RefObject<T | null>): DOMRefValue<T> {
   return {
     UNSAFE_getDOMNode() {
       return ref.current;
@@ -21,7 +21,7 @@ export function createDOMRef<T extends HTMLElement = HTMLElement>(ref: RefObject
   };
 }
 
-export function createFocusableRef<T extends HTMLElement = HTMLElement>(domRef: RefObject<T>, focusableRef: RefObject<FocusableElement> = domRef): FocusableRefValue<T> {
+export function createFocusableRef<T extends HTMLElement = HTMLElement>(domRef: RefObject<T | null>, focusableRef: RefObject<FocusableElement | null> = domRef): FocusableRefValue<T> {
   return {
     ...createDOMRef(domRef),
     focus() {
@@ -32,19 +32,19 @@ export function createFocusableRef<T extends HTMLElement = HTMLElement>(domRef: 
   };
 }
 
-export function useDOMRef<T extends HTMLElement = HTMLElement>(ref: DOMRef<T>): RefObject<T> {
+export function useDOMRef<T extends HTMLElement = HTMLElement>(ref: DOMRef<T>): RefObject<T | null> {
   let domRef = useRef<T>(null);
   useImperativeHandle(ref, () => createDOMRef(domRef));
   return domRef;
 }
 
-export function useFocusableRef<T extends HTMLElement = HTMLElement>(ref: FocusableRef<T>, focusableRef?: RefObject<FocusableElement>): RefObject<T> {
+export function useFocusableRef<T extends HTMLElement = HTMLElement>(ref: FocusableRef<T>, focusableRef?: RefObject<FocusableElement | null>): RefObject<T | null> {
   let domRef = useRef<T>(null);
   useImperativeHandle(ref, () => createFocusableRef(domRef, focusableRef));
   return domRef;
 }
 
-export function unwrapDOMRef<T extends HTMLElement>(ref: RefObject<DOMRefValue<T>>): RefObject<T> {
+export function unwrapDOMRef<T extends HTMLElement>(ref: RefObject<DOMRefValue<T> | null>): RefObject<T | null> {
   return {
     get current() {
       return ref.current && ref.current.UNSAFE_getDOMNode();
@@ -52,6 +52,6 @@ export function unwrapDOMRef<T extends HTMLElement>(ref: RefObject<DOMRefValue<T
   };
 }
 
-export function useUnwrapDOMRef<T extends HTMLElement>(ref: RefObject<DOMRefValue<T>>) : RefObject<T> {
+export function useUnwrapDOMRef<T extends HTMLElement>(ref: RefObject<DOMRefValue<T> | null>) : RefObject<T | null> {
   return useMemo(() => unwrapDOMRef(ref), [ref]);
 }

--- a/packages/@react-spectrum/utils/src/useHasChild.ts
+++ b/packages/@react-spectrum/utils/src/useHasChild.ts
@@ -13,7 +13,7 @@
 import {RefObject, useState} from 'react';
 import {useLayoutEffect} from '@react-aria/utils';
 
-export function useHasChild(query: string, ref: RefObject<HTMLElement>) {
+export function useHasChild(query: string, ref: RefObject<HTMLElement | null>) {
   let [hasChild, setHasChild] = useState(true);
   useLayoutEffect(() => {
     setHasChild(!!(ref.current && ref.current.querySelector(query)));

--- a/packages/@react-stately/collections/src/useCollection.ts
+++ b/packages/@react-stately/collections/src/useCollection.ts
@@ -15,7 +15,7 @@ import {CollectionBuilder} from './CollectionBuilder';
 import {ReactElement, useMemo} from 'react';
 
 interface CollectionOptions<T, C extends Collection<Node<T>>> extends Omit<CollectionStateBase<T, C>, 'children'> {
-  children?: ReactElement | ReactElement[] | ((item: T) => ReactElement)
+  children?: ReactElement<any> | ReactElement<any>[] | ((item: T) => ReactElement<any>)
 }
 
 type CollectionFactory<T, C extends Collection<Node<T>>> = (node: Iterable<Node<T>>) => C;

--- a/packages/@react-stately/data/src/useAsyncList.ts
+++ b/packages/@react-stately/data/src/useAsyncList.ts
@@ -276,7 +276,7 @@ export function useAsyncList<T, C = string>(options: AsyncListOptions<T, C>): As
     initialFilterText = ''
   } = options;
 
-  let [data, dispatch] = useReducer<Reducer<AsyncListState<T, C>, Action<T, C>>>(reducer, {
+  let [data, dispatch] = useReducer<AsyncListState<T, C>, [Action<T, C>]>(reducer, {
     state: 'idle',
     error: null,
     items: [],

--- a/packages/@react-stately/datepicker/src/useDateFieldState.ts
+++ b/packages/@react-stately/datepicker/src/useDateFieldState.ts
@@ -212,7 +212,7 @@ export function useDateFieldState<T extends DateValue = DateValue>(props: DateFi
     () => props.value || props.defaultValue ? {...allSegments} : {}
   );
 
-  let clearedSegment = useRef<string>();
+  let clearedSegment = useRef<string>(undefined);
 
   // Reset placeholder when calendar changes
   let lastCalendarIdentifier = useRef(calendar.identifier);

--- a/packages/@react-stately/dnd/src/useDraggableCollectionState.ts
+++ b/packages/@react-stately/dnd/src/useDraggableCollectionState.ts
@@ -37,7 +37,7 @@ export interface DraggableCollectionState {
   /** Returns the items to drag for the given key. */
   getItems(key: Key): DragItem[],
   /** The ref of the element that will be rendered as the drag preview while dragging. */
-  preview?: RefObject<DragPreviewRenderer>,
+  preview?: RefObject<DragPreviewRenderer | null>,
   /** Function that returns the drop operations that are allowed for the dragged items. If not provided, all drop operations are allowed. */
   getAllowedDropOperations?: () => DropOperation[],
   /** Begins a drag for the given key. This triggers the onDragStart event. */

--- a/packages/@react-stately/table/src/useTreeGridState.ts
+++ b/packages/@react-stately/table/src/useTreeGridState.ts
@@ -73,7 +73,7 @@ export function UNSTABLE_useTreeGridState<T extends object>(props: TreeGridState
   }), [children, showSelectionCheckboxes, selectionMode, showDragButtons]);
 
   let builder = useMemo(() => new CollectionBuilder<T>(), []);
-  let nodes = useMemo(() => builder.build({children: children as ReactElement[]}, context), [builder, children, context]);
+  let nodes = useMemo(() => builder.build({children: children as ReactElement<any>[]}, context), [builder, children, context]);
   let treeGridCollection = useMemo(() => {
     return generateTreeGridCollection<T>(nodes, {showSelectionCheckboxes, showDragButtons, expandedKeys});
   }, [nodes, showSelectionCheckboxes, showDragButtons, expandedKeys]);

--- a/packages/@react-stately/tooltip/src/useTooltipTriggerState.ts
+++ b/packages/@react-stately/tooltip/src/useTooltipTriggerState.ts
@@ -45,7 +45,7 @@ export function useTooltipTriggerState(props: TooltipTriggerProps = {}): Tooltip
   let {delay = TOOLTIP_DELAY, closeDelay = TOOLTIP_COOLDOWN} = props;
   let {isOpen, open, close} = useOverlayTriggerState(props);
   let id = useMemo(() => `${++tooltipId}`, []);
-  let closeTimeout = useRef<ReturnType<typeof setTimeout>>();
+  let closeTimeout = useRef<ReturnType<typeof setTimeout>>(undefined);
 
   let ensureTooltipEntry = () => {
     tooltips[id] = hideTooltip;

--- a/packages/@react-stately/tree/stories/useTreeState.stories.tsx
+++ b/packages/@react-stately/tree/stories/useTreeState.stories.tsx
@@ -51,7 +51,7 @@ function TreeExample(props = {}) {
 
 function Tree(props) {
   let state = useTreeState(props);
-  let ref = useRef();
+  let ref = useRef(undefined);
 
   let keyboardDelegate = useMemo(() => new TreeKeyboardDelegate(state.collection, state.disabledKeys), [state.collection, state.disabledKeys]);
 
@@ -81,7 +81,7 @@ function TreeNodes({nodes, state}) {
 }
 
 function TreeItem({node, state}) {
-  let ref = useRef();
+  let ref = useRef(undefined);
 
   let {itemProps} = useSelectableItem({
     key: node.key,

--- a/packages/@react-types/dialog/src/index.d.ts
+++ b/packages/@react-types/dialog/src/index.d.ts
@@ -31,7 +31,7 @@ export interface SpectrumDialogTriggerProps extends OverlayTriggerProps, Positio
    */
   hideArrow?: boolean,
   /** The ref of the element the Dialog should visually attach itself to. Defaults to the trigger button if not defined. */
-  targetRef?: RefObject<HTMLElement>,
+  targetRef?: RefObject<HTMLElement | null>,
   /** Whether a modal type Dialog should be dismissable. */
   isDismissable?: boolean,
   /** Whether pressing the escape key to close the dialog should be disabled. */

--- a/packages/@react-types/shared/src/dnd.d.ts
+++ b/packages/@react-types/shared/src/dnd.d.ts
@@ -281,7 +281,7 @@ export interface DraggableCollectionProps {
   /** A function that returns the items being dragged. */
   getItems: (keys: Set<Key>) => DragItem[],
   /** The ref of the element that will be rendered as the drag preview while dragging. */
-  preview?: RefObject<DragPreviewRenderer>,
+  preview?: RefObject<DragPreviewRenderer | null>,
   /** Function that returns the drop operations that are allowed for the dragged items. If not provided, all drop operations are allowed. */
   getAllowedDropOperations?: () => DropOperation[]
 }

--- a/packages/@react-types/textfield/src/index.d.ts
+++ b/packages/@react-types/textfield/src/index.d.ts
@@ -47,7 +47,7 @@ export interface AriaTextFieldProps extends TextFieldProps, AriaLabelingProps, F
 
 export interface SpectrumTextFieldProps extends SpectrumTextInputBase, Omit<AriaTextFieldProps, 'isInvalid' | 'validationState'>, SpectrumFieldValidation<string>, SpectrumLabelableProps, StyleProps {
   /** An icon to display at the start of the input. */
-  icon?: ReactElement | null,
+  icon?: ReactElement<any> | null,
   /** Whether the input should be displayed with a quiet style. */
   isQuiet?: boolean
 }

--- a/packages/dev/docs/pages/react-aria/home/SwitchAnimation.tsx
+++ b/packages/dev/docs/pages/react-aria/home/SwitchAnimation.tsx
@@ -16,7 +16,7 @@ import React, {useCallback, useRef, useState} from 'react';
 import {Switch} from 'react-aria-components';
 
 export function SwitchAnimation() {
-  let ref = useRef();
+  let ref = useRef(undefined);
   let [isAnimating, setAnimating] = useState(false);
   let [isSelected, setSelected] = useState(true);
 

--- a/packages/dev/docs/pages/react-aria/home/components.tsx
+++ b/packages/dev/docs/pages/react-aria/home/components.tsx
@@ -76,7 +76,7 @@ export function Arrow({href, children, textX, x1, x2, points, y, marker = 'marke
   );
 }
 
-export const Finger = React.forwardRef((props: HTMLAttributes<HTMLDivElement>, ref: RefObject<HTMLDivElement>) => {
+export const Finger = React.forwardRef((props: HTMLAttributes<HTMLDivElement>, ref: RefObject<HTMLDivElement | null>) => {
   return <div ref={ref} className="z-10 pointer-events-none absolute w-10 h-10 rounded-full border border-black/80 bg-black/80 dark:border-white/80 dark:bg-white/80 dark:mix-blend-difference opacity-0 [--hover-opacity:0.15] [--pressed-opacity:0.3] forced-colors:[--hover-opacity:0.5] forced-colors:[--pressed-opacity:1] forced-colors:!bg-[Highlight] forced-colors:!mix-blend-normal" {...props} />;
 });
 

--- a/packages/dev/docs/pages/react-aria/home/utils.ts
+++ b/packages/dev/docs/pages/react-aria/home/utils.ts
@@ -66,7 +66,7 @@ function sleep(ms: number) {
   };
 }
 
-export function useIntersectionObserver(ref: RefObject<HTMLElement>, onIntersect: () => Function | void) {
+export function useIntersectionObserver(ref: RefObject<HTMLElement | null>, onIntersect: () => Function | void) {
   useEffect(() => {
     let element = ref.current;
     if (!element) {

--- a/packages/react-aria-components/src/Breadcrumbs.tsx
+++ b/packages/react-aria-components/src/Breadcrumbs.tsx
@@ -43,7 +43,7 @@ function Breadcrumbs<T extends object>(props: BreadcrumbsProps<T>, ref: Forwarde
 interface BreadcrumbsInnerProps<T> {
   props: BreadcrumbsProps<T>,
   collection: Collection<Node<T>>,
-  breadcrumbsRef: RefObject<HTMLOListElement>
+  breadcrumbsRef: RefObject<HTMLOListElement | null>
 }
 
 function BreadcrumbsInner<T extends object>({props, collection, breadcrumbsRef: ref}: BreadcrumbsInnerProps<T>) {

--- a/packages/react-aria-components/src/ComboBox.tsx
+++ b/packages/react-aria-components/src/ComboBox.tsx
@@ -100,7 +100,7 @@ function ComboBox<T extends object>(props: ComboBoxProps<T>, ref: ForwardedRef<H
 interface ComboBoxInnerProps<T extends object> {
   props: ComboBoxProps<T>,
   collection: Collection<Node<T>>,
-  comboBoxRef: RefObject<HTMLDivElement>
+  comboBoxRef: RefObject<HTMLDivElement | null>
 }
 
 function ComboBoxInner<T extends object>({props, collection, comboBoxRef: ref}: ComboBoxInnerProps<T>) {

--- a/packages/react-aria-components/src/GridList.tsx
+++ b/packages/react-aria-components/src/GridList.tsx
@@ -76,7 +76,7 @@ function GridList<T extends object>(props: GridListProps<T>, ref: ForwardedRef<H
 interface GridListInnerProps<T extends object> {
   props: GridListProps<T>,
   collection: Collection<Node<T>>,
-  gridListRef: RefObject<HTMLDivElement>
+  gridListRef: RefObject<HTMLDivElement | null>
 }
 
 function GridListInner<T extends object>({props, collection, gridListRef: ref}: GridListInnerProps<T>) {
@@ -397,7 +397,7 @@ function GridListDropIndicatorWrapper(props: DropIndicatorProps, ref: ForwardedR
 interface GridListDropIndicatorProps extends DropIndicatorProps {
   dropIndicatorProps: React.HTMLAttributes<HTMLElement>,
   isDropTarget: boolean,
-  buttonRef: RefObject<HTMLDivElement>
+  buttonRef: RefObject<HTMLDivElement | null>
 }
 
 function GridListDropIndicator(props: GridListDropIndicatorProps, ref: ForwardedRef<HTMLElement>) {
@@ -418,16 +418,16 @@ function GridListDropIndicator(props: GridListDropIndicatorProps, ref: Forwarded
   });
 
   return (
-    <div
+    (<div
       {...renderProps}
       role="row"
-      ref={ref as RefObject<HTMLDivElement>}
+      ref={ref as RefObject<HTMLDivElement | null>}
       data-drop-target={isDropTarget || undefined}>
       <div role="gridcell">
         <div {...visuallyHiddenProps} role="button" {...dropIndicatorProps} ref={buttonRef} />
         {renderProps.children}
       </div>
-    </div>
+    </div>)
   );
 }
 

--- a/packages/react-aria-components/src/ListBox.tsx
+++ b/packages/react-aria-components/src/ListBox.tsx
@@ -121,7 +121,7 @@ export {_ListBox as ListBox};
 interface ListBoxInnerProps<T> {
   state: ListState<T>,
   props: ListBoxProps<T> & AriaListBoxOptions<T>,
-  listBoxRef: RefObject<HTMLDivElement>
+  listBoxRef: RefObject<HTMLDivElement | null>
 }
 
 function ListBoxInner<T>({state, props, listBoxRef}: ListBoxInnerProps<T>) {
@@ -491,13 +491,13 @@ function ListBoxtDropIndicator(props: ListBoxDropIndicatorProps, ref: ForwardedR
   });
 
   return (
-    <div
+    (<div
       {...dropIndicatorProps}
       {...renderProps}
       // eslint-disable-next-line
       role="option"
-      ref={ref as RefObject<HTMLDivElement>}
-      data-drop-target={isDropTarget || undefined} />
+      ref={ref as RefObject<HTMLDivElement | null>}
+      data-drop-target={isDropTarget || undefined} />)
   );
 }
 

--- a/packages/react-aria-components/src/Menu.tsx
+++ b/packages/react-aria-components/src/Menu.tsx
@@ -106,9 +106,9 @@ export interface SubmenuTriggerProps {
  *
  * @version alpha
  */
-export function SubmenuTrigger(props: SubmenuTriggerProps, ref: ForwardedRef<HTMLDivElement>): JSX.Element | null {
+export const SubmenuTrigger = React.forwardRef(function SubmenuTrigger(props: SubmenuTriggerProps, ref: ForwardedRef<HTMLDivElement>): JSX.Element | null {
   return useSSRCollectionNode('submenutrigger', props, ref, props.children, props.children[0]);
-}
+});
 
 function SubmenuTriggerInner(props) {
   let {item, parentMenuRef} = props;

--- a/packages/react-aria-components/src/Menu.tsx
+++ b/packages/react-aria-components/src/Menu.tsx
@@ -22,7 +22,19 @@ import {KeyboardContext} from './Keyboard';
 import {OverlayTriggerStateContext} from './Dialog';
 import {PopoverContext, PopoverProps} from './Popover';
 import {PressResponder, useHover, useInteractOutside} from '@react-aria/interactions';
-import React, {createContext, ForwardedRef, forwardRef, ReactElement, ReactNode, RefObject, useCallback, useContext, useRef, useState} from 'react';
+import React, {
+  createContext,
+  ForwardedRef,
+  forwardRef,
+  ReactElement,
+  ReactNode,
+  RefObject,
+  useCallback,
+  useContext,
+  useRef,
+  useState,
+  type JSX,
+} from 'react';
 import {RootMenuTriggerState, UNSTABLE_useSubmenuTriggerState} from '@react-stately/menu';
 import {Separator, SeparatorContext} from './Separator';
 import {TextContext} from './Text';
@@ -136,7 +148,7 @@ function Menu<T extends object>(props: MenuProps<T>, ref: ForwardedRef<HTMLDivEl
 interface MenuInnerProps<T> {
   props: MenuProps<T>,
   collection: BaseCollection<T>,
-  menuRef: RefObject<HTMLDivElement>
+  menuRef: RefObject<HTMLDivElement | null>
 }
 
 function MenuInner<T extends object>({props, collection, menuRef: ref}: MenuInnerProps<T>) {
@@ -211,7 +223,7 @@ export {_Menu as Menu};
 
 interface MenuSectionProps<T> extends StyleProps {
   section: Node<T>,
-  parentMenuRef: RefObject<HTMLDivElement>
+  parentMenuRef: RefObject<HTMLDivElement | null>
 }
 
 function MenuSection<T>({section, className, style, parentMenuRef, ...otherProps}: MenuSectionProps<T>) {
@@ -356,7 +368,7 @@ function MenuItemInner<T>({item}: MenuItemInnerProps<T>) {
 interface MenuItemTriggerInnerProps<T> {
   item: Node<T>,
   popover: ReactElement,
-  parentMenuRef: RefObject<HTMLDivElement>,
+  parentMenuRef: RefObject<HTMLDivElement | null>,
   delay?: number
 }
 

--- a/packages/react-aria-components/src/Modal.tsx
+++ b/packages/react-aria-components/src/Modal.tsx
@@ -36,7 +36,7 @@ export interface ModalOverlayProps extends AriaModalOverlayProps, OverlayTrigger
 
 interface InternalModalContextValue {
   modalProps: DOMAttributes,
-  modalRef: RefObject<HTMLDivElement>,
+  modalRef: RefObject<HTMLDivElement | null>,
   isExiting: boolean,
   isDismissable?: boolean
 }
@@ -101,8 +101,8 @@ function Modal(props: ModalOverlayProps, ref: ForwardedRef<HTMLDivElement>) {
 }
 
 interface ModalOverlayInnerProps extends ModalOverlayProps {
-  overlayRef: RefObject<HTMLDivElement>,
-  modalRef: RefObject<HTMLDivElement>,
+  overlayRef: RefObject<HTMLDivElement | null>,
+  modalRef: RefObject<HTMLDivElement | null>,
   state: OverlayTriggerState,
   isExiting: boolean
 }

--- a/packages/react-aria-components/src/Popover.tsx
+++ b/packages/react-aria-components/src/Popover.tsx
@@ -31,7 +31,7 @@ export interface PopoverProps extends Omit<PositionProps, 'isOpen'>, Omit<AriaPo
    * When used within a trigger component such as DialogTrigger, MenuTrigger, Select, etc.,
    * this is set automatically. It is only required when used standalone.
    */
-  triggerRef?: RefObject<Element>,
+  triggerRef?: RefObject<Element | null>,
   /**
    * Whether the popover is currently performing an entry animation.
    */
@@ -146,7 +146,7 @@ function PopoverInner({state, isExiting, UNSTABLE_portalContainer, ...props}: Po
     arrowSize: arrowWidth
   }, state);
 
-  let ref = props.popoverRef as RefObject<HTMLDivElement>;
+  let ref = props.popoverRef as RefObject<HTMLDivElement | null>;
   let isEntering = useEnterAnimation(ref, !!placement) || props.isEntering || false;
   let renderProps = useRenderProps({
     ...props,

--- a/packages/react-aria-components/src/Slider.tsx
+++ b/packages/react-aria-components/src/Slider.tsx
@@ -221,7 +221,7 @@ function SliderThumb(props: SliderThumbProps, ref: ForwardedRef<HTMLDivElement>)
   let {thumbProps, inputProps, labelProps, isDragging, isFocused, isDisabled} = useSliderThumb({
     ...props,
     index,
-    trackRef: trackRef as RefObject<HTMLDivElement>,
+    trackRef: trackRef as RefObject<HTMLDivElement | null>,
     inputRef,
     label
   }, state);

--- a/packages/react-aria-components/src/Table.tsx
+++ b/packages/react-aria-components/src/Table.tsx
@@ -785,7 +785,7 @@ function TableHeaderRow<T>({item}: {item: GridNode<T>}) {
 
 interface ColumnResizerContextValue {
   column: GridNode<unknown>,
-  triggerRef: RefObject<HTMLDivElement>
+  triggerRef: RefObject<HTMLDivElement | null>
 }
 
 const ColumnResizerContext = createContext<ColumnResizerContextValue | null>(null);
@@ -1188,7 +1188,7 @@ function TableDropIndicatorWrapper(props: DropIndicatorProps, ref: ForwardedRef<
 interface TableDropIndicatorProps extends DropIndicatorProps {
   dropIndicatorProps: React.HTMLAttributes<HTMLElement>,
   isDropTarget: boolean,
-  buttonRef: RefObject<HTMLDivElement>
+  buttonRef: RefObject<HTMLDivElement | null>
 }
 
 function TableDropIndicator(props: TableDropIndicatorProps, ref: ForwardedRef<HTMLElement>) {
@@ -1210,11 +1210,11 @@ function TableDropIndicator(props: TableDropIndicatorProps, ref: ForwardedRef<HT
   });
 
   return (
-    <tr
+    (<tr
       {...filterDOMProps(props as any)}
       {...renderProps}
       role="row"
-      ref={ref as RefObject<HTMLTableRowElement>}
+      ref={ref as RefObject<HTMLTableRowElement | null>}
       data-drop-target={isDropTarget || undefined}>
       <td
         role="gridcell"
@@ -1223,7 +1223,7 @@ function TableDropIndicator(props: TableDropIndicatorProps, ref: ForwardedRef<HT
         <div {...visuallyHiddenProps} role="button" {...dropIndicatorProps} ref={buttonRef} />
         {renderProps.children}
       </td>
-    </tr>
+    </tr>)
   );
 }
 

--- a/packages/react-aria-components/src/Tabs.tsx
+++ b/packages/react-aria-components/src/Tabs.tsx
@@ -142,7 +142,7 @@ function Tabs(props: TabsProps, ref: ForwardedRef<HTMLDivElement>) {
 interface TabsInnerProps {
   props: TabsProps,
   collection: Collection<Node<any>>,
-  tabsRef: RefObject<HTMLDivElement>
+  tabsRef: RefObject<HTMLDivElement | null>
 }
 
 function TabsInner({props, tabsRef: ref, collection}: TabsInnerProps) {

--- a/packages/react-aria-components/src/Tooltip.tsx
+++ b/packages/react-aria-components/src/Tooltip.tsx
@@ -29,7 +29,7 @@ export interface TooltipProps extends PositionProps, Pick<AriaPositionProps, 'ar
    *
    * When used within a TooltipTrigger this is set automatically. It is only required when used standalone.
    */
-  triggerRef?: RefObject<Element>,
+  triggerRef?: RefObject<Element | null>,
   /**
    * Whether the tooltip is currently performing an entry animation.
    */
@@ -116,7 +116,7 @@ function Tooltip({UNSTABLE_portalContainer, ...props}: TooltipProps, ref: Forwar
 const _Tooltip = /*#__PURE__*/ (forwardRef as forwardRefType)(Tooltip);
 export {_Tooltip as Tooltip};
 
-function TooltipInner(props: TooltipProps & {isExiting: boolean, tooltipRef: RefObject<HTMLDivElement>}) {
+function TooltipInner(props: TooltipProps & {isExiting: boolean, tooltipRef: RefObject<HTMLDivElement | null>}) {
   let state = useContext(TooltipTriggerStateContext)!;
 
   // Calculate the arrow size internally

--- a/packages/react-aria-components/src/Tree.tsx
+++ b/packages/react-aria-components/src/Tree.tsx
@@ -151,7 +151,7 @@ function Tree<T extends object>(props: TreeProps<T>, ref: ForwardedRef<HTMLDivEl
 interface TreeInnerProps<T extends object> {
   props: TreeProps<T>,
   collection: BaseCollection<T>,
-  treeRef: RefObject<HTMLDivElement>
+  treeRef: RefObject<HTMLDivElement | null>
 }
 
 function TreeInner<T extends object>({props, collection, treeRef: ref}: TreeInnerProps<T>) {

--- a/packages/react-aria-components/src/useDragAndDrop.tsx
+++ b/packages/react-aria-components/src/useDragAndDrop.tsx
@@ -47,7 +47,7 @@ interface DraggableCollectionStateOpts extends Omit<DraggableCollectionStateOpti
 
 interface DragHooks {
   useDraggableCollectionState?: (props: DraggableCollectionStateOpts) => DraggableCollectionState,
-  useDraggableCollection?: (props: DraggableCollectionOptions, state: DraggableCollectionState, ref: RefObject<HTMLElement>) => void,
+  useDraggableCollection?: (props: DraggableCollectionOptions, state: DraggableCollectionState, ref: RefObject<HTMLElement | null>) => void,
   useDraggableItem?: (props: DraggableItemProps, state: DraggableCollectionState) => DraggableItemResult,
   DragPreview?: typeof DragPreview,
   renderDragPreview?: (items: DragItem[]) => JSX.Element
@@ -55,9 +55,9 @@ interface DragHooks {
 
 interface DropHooks {
   useDroppableCollectionState?: (props: DroppableCollectionStateOptions) => DroppableCollectionState,
-  useDroppableCollection?: (props: DroppableCollectionOptions, state: DroppableCollectionState, ref: RefObject<HTMLElement>) => DroppableCollectionResult,
-  useDroppableItem?: (options: DroppableItemOptions, state: DroppableCollectionState, ref: RefObject<HTMLElement>) => DroppableItemResult,
-  useDropIndicator?: (props: AriaDropIndicatorProps, state: DroppableCollectionState, ref: RefObject<HTMLElement>) => DropIndicatorAria,
+  useDroppableCollection?: (props: DroppableCollectionOptions, state: DroppableCollectionState, ref: RefObject<HTMLElement | null>) => DroppableCollectionResult,
+  useDroppableItem?: (options: DroppableItemOptions, state: DroppableCollectionState, ref: RefObject<HTMLElement | null>) => DroppableItemResult,
+  useDropIndicator?: (props: AriaDropIndicatorProps, state: DroppableCollectionState, ref: RefObject<HTMLElement | null>) => DropIndicatorAria,
   renderDropIndicator?: (target: DropTarget) => JSX.Element,
   dropTargetDelegate?: DropTargetDelegate,
   ListDropTargetDelegate: typeof ListDropTargetDelegate
@@ -127,7 +127,7 @@ export function useDragAndDrop(options: DragAndDropOptions): DragAndDrop {
         return useDroppableCollectionState({...props, ...options});
       };
       hooks.useDroppableItem = useDroppableItem;
-      hooks.useDroppableCollection = function useDroppableCollectionOverride(props: DroppableCollectionOptions, state: DroppableCollectionState, ref: RefObject<HTMLElement>) {
+      hooks.useDroppableCollection = function useDroppableCollectionOverride(props: DroppableCollectionOptions, state: DroppableCollectionState, ref: RefObject<HTMLElement | null>) {
         return useDroppableCollection({...props, ...options}, state, ref);
       };
       hooks.useDropIndicator = useDropIndicator;

--- a/packages/react-aria-components/src/utils.tsx
+++ b/packages/react-aria-components/src/utils.tsx
@@ -183,7 +183,7 @@ export function useSlottedContext<T>(context: Context<SlottedContextValue<T>>, s
   return ctx;
 }
 
-export function useContextProps<T, U extends SlotProps, E extends Element>(props: T & SlotProps, ref: ForwardedRef<E>, context: Context<ContextValue<U, E>>): [T, RefObject<E>] {
+export function useContextProps<T, U extends SlotProps, E extends Element>(props: T & SlotProps, ref: ForwardedRef<E>, context: Context<ContextValue<U, E>>): [T, RefObject<E | null>] {
   let ctx = useSlottedContext(context, props.slot) || {};
   // @ts-ignore - TS says "Type 'unique symbol' cannot be used as an index type." but not sure why.
   let {ref: contextRef, ...contextProps} = ctx;
@@ -228,13 +228,13 @@ export function useSlot(): [RefCallback<Element>, boolean] {
   return [ref, hasSlot];
 }
 
-export function useEnterAnimation(ref: RefObject<HTMLElement>, isReady: boolean = true) {
+export function useEnterAnimation(ref: RefObject<HTMLElement | null>, isReady: boolean = true) {
   let [isEntering, setEntering] = useState(true);
   useAnimation(ref, isEntering && isReady, useCallback(() => setEntering(false), []));
   return isEntering && isReady;
 }
 
-export function useExitAnimation(ref: RefObject<HTMLElement>, isOpen: boolean) {
+export function useExitAnimation(ref: RefObject<HTMLElement | null>, isOpen: boolean) {
   // State to trigger a re-render after animation is complete, which causes the element to be removed from the DOM.
   // Ref to track the state we're in, so we don't immediately reset isExiting to true after the animation.
   let [isExiting, setExiting] = useState(false);
@@ -264,7 +264,7 @@ export function useExitAnimation(ref: RefObject<HTMLElement>, isOpen: boolean) {
   return isExiting;
 }
 
-function useAnimation(ref: RefObject<HTMLElement>, isActive: boolean, onEnd: () => void) {
+function useAnimation(ref: RefObject<HTMLElement | null>, isActive: boolean, onEnd: () => void) {
   let prevAnimation = useRef<string | null>(null);
   if (isActive && ref.current) {
     // This is ok because we only read it in the layout effect below, immediately after the commit phase.

--- a/yarn.lock
+++ b/yarn.lock
@@ -6311,11 +6311,6 @@
   resolved "https://registry.yarnpkg.com/@types/pretty-hrtime/-/pretty-hrtime-1.0.1.tgz#72a26101dc567b0d68fd956cf42314556e42d601"
   integrity sha512-VjID5MJb1eGKthz2qUerWT8+R4b9N+CHvGCzg9fn4kWZgaF9AhdYikQio3R7wV8YY1NsQKPaCwKz1Yff+aHNUQ==
 
-"@types/prop-types@*":
-  version "15.7.3"
-  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
-  integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
-
 "@types/q@^1.5.1":
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.4.tgz#15925414e0ad2cd765bfef58842f7e26a7accb24"
@@ -6326,19 +6321,18 @@
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
   integrity sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==
 
-"@types/react-dom@^18.0.0":
-  version "18.2.4"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.2.4.tgz#13f25bfbf4e404d26f62ac6e406591451acba9e0"
-  integrity sha512-G2mHoTMTL4yoydITgOGwWdWMVd8sNgyEP85xVmMKAPUBwQWm9wBPQUmvbeF4V3WBY1P7mmL4BkjQ0SqUpf1snw==
+"@types/react-dom@^18.0.0", "@types/react-dom@npm:types-react-dom@19.0.0-alpha.2":
+  version "19.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/types-react-dom/-/types-react-dom-19.0.0-alpha.2.tgz#c58929f7a519fe91b91e57e9efd34396a1f7db9e"
+  integrity sha512-aGr3YLlqMnJAs1k2kOdlINCNNgGVNfIa/yIweQwF3o+iJpWLih0eF5wSzyxbaaYOu8QSEGze67bPDRKFsnnJOg==
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@18.2.28", "@types/react@>=16", "@types/react@^18.2.28":
-  version "18.2.28"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.28.tgz#86877465c0fcf751659a36c769ecedfcfacee332"
-  integrity sha512-ad4aa/RaaJS3hyGz0BGegdnSRXQBkd1CCYDCdNjBPg90UUpLgo+WlJqb9fMYUxtehmzF3PJaTWqRZjko6BRzBg==
+"@types/react@*", "@types/react@>=16", "@types/react@npm:types-react@19.0.0-alpha.2":
+  version "19.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/types-react/-/types-react-19.0.0-alpha.2.tgz#dab2accd8062be23f22b56f5c853ab2d3b95c592"
+  integrity sha512-RQzbsByxCdbeJrhloYiVuXTQzcYDHN12gtTAY5gRfYxp5opnABDM6rbUZx/flJ6ams0vH3DSVVhVKoXQCJTN9Q==
   dependencies:
-    "@types/prop-types" "*"
     "@types/scheduler" "*"
     csstype "^3.0.2"
 


### PR DESCRIPTION
Closes https://github.com/eps1lon/DefinitelyTyped/issues/30

## Changes

- A `forwardRef` render function was used as a component. This was a bug that couldn't be caught with types but now is. Previously the types assumed the second argument was legacy context. The fix was to wrap the render function in `forwardRef`: [`1f9935a` (#1)](https://github.com/eps1lon/react-spectrum/pull/1/commits/1f9935a751dfc97a3c9e055e2ab7df82cc8414c3)
- breaking changes due to `useReducer` type parameters. The manual change is quite trivial and I never found more than one issue per repo. Still, worth a codemod but low pri: :https://github.com/eps1lon/types-react-codemod/issues/375
- Storybook story fns were being used as components. They matched component types in React 18 since the second argument was treated as legacy context. The fix was always to use them as `StoryFn(propsLike)` instead of `<StoryFn {...propsLike} />`. I only illustrated the migration in one callsite: [`48971e8` (#1)](https://github.com/eps1lon/react-spectrum/pull/1/commits/48971e80f2575b1a539bfc5bebe355c29bdc3016). There are too many to do manually. Worth to codemod this but I'm not working on it.
- relied on `createFactory` types without a need: [`d566212` (#1)](https://github.com/eps1lon/react-spectrum/pull/1/commits/d566212ccb1f9f810ca8ed7d465db84977b0983f)

## Unresolved issues

- `framer-motion` uses the deprecated, global JSX namespace. Tracking in https://github.com/eps1lon/DefinitelyTyped/issues/25
- `lucide-react` uses removed `ReactSVG` type. Tracking in https://github.com/eps1lon/DefinitelyTyped/issues/25